### PR TITLE
ACE_Process std file handles on Windows

### DIFF
--- a/TAO/TAO_IDL/driver/drv_args.cpp
+++ b/TAO/TAO_IDL/driver/drv_args.cpp
@@ -118,9 +118,9 @@ void
 DRV_usage (void)
 {
   ACE_DEBUG ((LM_DEBUG,
-              ACE_TEXT ("%s: usage: %s [flag | file]*\n"),
-              ACE_TEXT_CHAR_TO_TCHAR (idl_global->prog_name ()),
-              ACE_TEXT_CHAR_TO_TCHAR (idl_global->prog_name ())));
+              ACE_TEXT ("%C: usage: %C [flag | file]*\n"),
+              idl_global->prog_name (),
+              idl_global->prog_name ()));
 
   ACE_DEBUG ((LM_DEBUG,
               ACE_TEXT ("Legal flags:\n")));

--- a/TAO/TAO_IDL/driver/drv_preproc.cpp
+++ b/TAO/TAO_IDL/driver/drv_preproc.cpp
@@ -1354,7 +1354,14 @@ DRV_pre_proc (const char *myfile)
           throw Bailout ();
         }
 
-      cpp_options.set_handles (ACE_INVALID_HANDLE, fd);
+      if (cpp_options.set_handles (ACE_INVALID_HANDLE, fd) == -1)
+        {
+          ACE_ERROR ((LM_ERROR,
+                      "%s: cannot set stdout for child process: %p\n",
+                      ACE_TEXT_CHAR_TO_TCHAR (idl_global->prog_name ())));
+
+          throw Bailout ();
+        }
     }
 
   if (idl_global->compile_flags () & IDL_CF_INFORMATIVE)

--- a/TAO/TAO_IDL/driver/drv_preproc.cpp
+++ b/TAO/TAO_IDL/driver/drv_preproc.cpp
@@ -1356,9 +1356,8 @@ DRV_pre_proc (const char *myfile)
 
       if (cpp_options.set_handles (ACE_INVALID_HANDLE, fd) == -1)
         {
-          ACE_ERROR ((LM_ERROR,
-                      "%s: cannot set stdout for child process: %p\n",
-                      ACE_TEXT_CHAR_TO_TCHAR (idl_global->prog_name ())));
+          ACE_ERROR ((LM_ERROR, "%C: cannot set stdout for child process: %p\n",
+                      idl_global->prog_name ()));
 
           throw Bailout ();
         }

--- a/TAO/TAO_IDL/tao_idl.cpp
+++ b/TAO/TAO_IDL/tao_idl.cpp
@@ -99,9 +99,9 @@ void
 DRV_version (void)
 {
   ACE_DEBUG ((LM_DEBUG,
-              "%s\n"
+              "%C\n"
               "TAO_IDL_FE, version %s (Based on Sun IDL FE, version %s)\n",
-              ACE_TEXT_CHAR_TO_TCHAR (idl_global->prog_name ()),
+              idl_global->prog_name (),
               ACE_TEXT (TAO_VERSION),
               ACE_TEXT (SUN_IDL_FE_VERSION)));
 


### PR DESCRIPTION
Allow redirection of child's stdout/stderr when there is no
stdin handle available (for example when running in a service).
TAO_IDL drv_preproc: check for errors from ACE_Process