### PR TITLE
Fix missing separator in rules.lib.GNU

### DIFF
--- a/ACE/include/makeinclude/rules.lib.GNU
+++ b/ACE/include/makeinclude/rules.lib.GNU
@@ -198,7 +198,7 @@ $(VLIB): $(VLOBJS)
   ifdef ibmcxx_build
 # This is required to get AIX IBM C/C++ to instantiate and compile the needed
 # templates.
-                      if test -s ./$(TEMPINCDIR)/*.C; \
+	if test -s ./$(TEMPINCDIR)/*.C; \
 	then \
 		$(LINK.cc) $(LINK_OUTPUT_FLAG) dummy $(LDFLAGS) $(ACE_ROOT)/etc/xlc_dummy.cpp $^ $(ACE_SHLIBS) $(LIBS); \
 		$(RM) dummy; \


### PR DESCRIPTION
Build ACE in AIX 5.1 error:

* Use ace/config-aix-5.x.h as config.h
* Use platform_aix_g++.GNU as platform_aix_g++.GNU

```
ACE/include/makeinclude/rules.lib.GNU:201: *** missing separator (did you mean TAB instead of 8 spaces?). Stop.
```

