### PR TITLE
Set is_default_qos to false. One should explicitly set the qos_profile s...

### DIFF
--- a/CIAO/connectors/dds4ccm/examples/Hello/descriptors/USER_QOS_PROFILES.xml
+++ b/CIAO/connectors/dds4ccm/examples/Hello/descriptors/USER_QOS_PROFILES.xml
@@ -28,7 +28,7 @@ RTI Data Distribution Service user manual.
 
              A QoS profile groups a set of related QoS.
         -->
-    <qos_profile name="HelloProfile" is_default_qos="true">
+    <qos_profile name="HelloProfile" is_default_qos="false">
       <!-- QoS used to configure the data writer created in the example code -->
       <datawriter_qos>
         <reliability>

--- a/CIAO/connectors/dds4ccm/examples/IDL2CPPWrapper/Shapes/descriptors/USER_QOS_PROFILES.xml
+++ b/CIAO/connectors/dds4ccm/examples/IDL2CPPWrapper/Shapes/descriptors/USER_QOS_PROFILES.xml
@@ -28,7 +28,7 @@ RTI Data Distribution Service user manual.
 
              A QoS profile groups a set of related QoS.
         -->
-    <qos_profile name="ShapesProfile" is_default_qos="true">
+    <qos_profile name="ShapesProfile" is_default_qos="false">
       <!-- QoS used to configure the data writer created in the example code -->
       <datawriter_qos>
         <reliability>

--- a/CIAO/connectors/dds4ccm/examples/ShapesContr/descriptors/USER_QOS_PROFILES.xml
+++ b/CIAO/connectors/dds4ccm/examples/ShapesContr/descriptors/USER_QOS_PROFILES.xml
@@ -28,7 +28,7 @@ RTI Data Distribution Service user manual.
 
              A QoS profile groups a set of related QoS.
         -->
-    <qos_profile name="square" is_default_qos="true">
+    <qos_profile name="square" is_default_qos="false">
       <!-- QoS used to configure the data writer created in the example code -->
       <datawriter_qos>
           <reliability>

--- a/CIAO/connectors/dds4ccm/performance-tests/DDSLatency/descriptors/USER_QOS_PROFILES.xml
+++ b/CIAO/connectors/dds4ccm/performance-tests/DDSLatency/descriptors/USER_QOS_PROFILES.xml
@@ -31,7 +31,7 @@
 
          A QoS profile groups a set of related QoS.
          -->
-    <qos_profile name="UDPv4QoS" is_default_qos="true">
+    <qos_profile name="UDPv4QoS" is_default_qos="false">
       <!-- QoS used to configure the data writer created in the example code -->
       <participant_qos>
         <receiver_pool>
@@ -126,7 +126,7 @@
       </datareader_qos>
     </qos_profile>
 
-    <qos_profile name="SharedMemQos" is_default_qos="true">
+    <qos_profile name="SharedMemQos" is_default_qos="false">
       <participant_qos>
         <transport_builtin>
           <mask>DDS_TRANSPORTBUILTIN_SHMEM</mask>

--- a/CIAO/connectors/dds4ccm/performance-tests/DDSThroughput/descriptors/USER_QOS_PROFILES.xml
+++ b/CIAO/connectors/dds4ccm/performance-tests/DDSThroughput/descriptors/USER_QOS_PROFILES.xml
@@ -28,7 +28,7 @@ RTI Data Distribution Service user manual.
 
              A QoS profile groups a set of related QoS.
         -->
-    <qos_profile name="ThroughputPartQoS" is_default_qos="true">
+    <qos_profile name="ThroughputPartQoS" is_default_qos="false">
       <!-- QoS used to configure the data writer created in the example code -->
       <participant_qos>
         <receiver_pool>
@@ -51,7 +51,7 @@ RTI Data Distribution Service user manual.
       </participant_qos>
       </qos_profile>
 
-    <qos_profile name="ThroughputQoS" is_default_qos="true">
+    <qos_profile name="ThroughputQoS" is_default_qos="false">
       <!-- QoS used to configure the data writer created in the example code -->
       <participant_qos>
       <receiver_pool>
@@ -105,7 +105,7 @@ RTI Data Distribution Service user manual.
       </datareader_qos>
     </qos_profile>
 
-    <qos_profile name="ThroughputCmdQoS" is_default_qos="true">
+    <qos_profile name="ThroughputCmdQoS" is_default_qos="false">
       <!-- QoS used to configure the data writer created in the example code -->
       <participant_qos>
         <receiver_pool>

--- a/CIAO/connectors/dds4ccm/performance-tests/Keyed/descriptors/USER_QOS_PROFILES.xml
+++ b/CIAO/connectors/dds4ccm/performance-tests/Keyed/descriptors/USER_QOS_PROFILES.xml
@@ -28,7 +28,7 @@ RTI Data Distribution Service user manual.
 
              A QoS profile groups a set of related QoS.
         -->
-    <qos_profile name="LatencyQoS" is_default_qos="true">
+    <qos_profile name="LatencyQoS" is_default_qos="false">
       <!-- QoS used to configure the data writer created in the example code -->
       <datawriter_qos>
         <reliability>

--- a/CIAO/connectors/dds4ccm/performance-tests/Latency/descriptors/USER_QOS_PROFILES.xml
+++ b/CIAO/connectors/dds4ccm/performance-tests/Latency/descriptors/USER_QOS_PROFILES.xml
@@ -31,7 +31,7 @@
 
          A QoS profile groups a set of related QoS.
          -->
-    <qos_profile name="UDPv4QoS" is_default_qos="true">
+    <qos_profile name="UDPv4QoS" is_default_qos="false">
       <!-- QoS used to configure the data writer created in the example code -->
       <participant_qos>
         <receiver_pool>
@@ -126,7 +126,7 @@
       </datareader_qos>
     </qos_profile>
 
-    <qos_profile name="SharedMemQos" is_default_qos="true">
+    <qos_profile name="SharedMemQos" is_default_qos="false">
       <participant_qos>
         <transport_builtin>
           <mask>DDS_TRANSPORTBUILTIN_SHMEM</mask>

--- a/CIAO/connectors/dds4ccm/performance-tests/Throughput/descriptors/USER_QOS_PROFILES.xml
+++ b/CIAO/connectors/dds4ccm/performance-tests/Throughput/descriptors/USER_QOS_PROFILES.xml
@@ -28,7 +28,7 @@ RTI Data Distribution Service user manual.
 
              A QoS profile groups a set of related QoS.
         -->
-    <qos_profile name="ThroughputQoS" is_default_qos="true">
+    <qos_profile name="ThroughputQoS" is_default_qos="false">
       <!-- QoS used to configure the data writer created in the example code -->
       <participant_qos>
         <receiver_pool>
@@ -82,7 +82,7 @@ RTI Data Distribution Service user manual.
       </datareader_qos>
     </qos_profile>
 
-    <qos_profile name="ThroughputCmdQoS" is_default_qos="true">
+    <qos_profile name="ThroughputCmdQoS" is_default_qos="false">
       <!-- QoS used to configure the data writer created in the example code -->
       <participant_qos>
         <receiver_pool>

--- a/CIAO/connectors/dds4ccm/tests/CSLDeadline/descriptors/USER_QOS_PROFILES.xml
+++ b/CIAO/connectors/dds4ccm/tests/CSLDeadline/descriptors/USER_QOS_PROFILES.xml
@@ -28,7 +28,7 @@ RTI Data Distribution Service user manual.
 
              A QoS profile groups a set of related QoS.
         -->
-    <qos_profile name="HelloProfile" is_default_qos="true">
+    <qos_profile name="HelloProfile" is_default_qos="false">
       <!-- QoS used to configure the data writer created in the example code -->
       <datawriter_qos>
         <reliability>

--- a/CIAO/connectors/dds4ccm/tests/CSLQoS/descriptors/USER_QOS_PROFILES.xml
+++ b/CIAO/connectors/dds4ccm/tests/CSLQoS/descriptors/USER_QOS_PROFILES.xml
@@ -28,7 +28,7 @@ RTI Data Distribution Service user manual.
 
              A QoS profile groups a set of related QoS.
         -->
-    <qos_profile name="SenderProfile" is_default_qos="true">
+    <qos_profile name="SenderProfile" is_default_qos="false">
       <!-- QoS used to configure the data writer created in the example code -->
       <datawriter_qos>
         <reliability>
@@ -56,7 +56,7 @@ RTI Data Distribution Service user manual.
       </datawriter_qos>
     </qos_profile>
 
-    <qos_profile name="ReceiverProfile" is_default_qos="true">
+    <qos_profile name="ReceiverProfile" is_default_qos="false">
       <datareader_qos>
         <reliability>
           <kind>RELIABLE_RELIABILITY_QOS</kind>

--- a/CIAO/connectors/dds4ccm/tests/CSLSampleRejected/descriptors/USER_QOS_PROFILES.xml
+++ b/CIAO/connectors/dds4ccm/tests/CSLSampleRejected/descriptors/USER_QOS_PROFILES.xml
@@ -30,7 +30,7 @@ RTI Data Distribution Service user manual.
 
              A QoS profile groups a set of related QoS.
         -->
-    <qos_profile name="HelloProfile" is_default_qos="true">
+    <qos_profile name="HelloProfile" is_default_qos="false">
       <!-- QoS used to configure the data writer created in the example code -->
       <datawriter_qos>
         <reliability>

--- a/CIAO/connectors/dds4ccm/tests/CSLUnexpStat/descriptors/USER_QOS_PROFILES.xml
+++ b/CIAO/connectors/dds4ccm/tests/CSLUnexpStat/descriptors/USER_QOS_PROFILES.xml
@@ -28,7 +28,7 @@ RTI Data Distribution Service user manual.
 
              A QoS profile groups a set of related QoS.
         -->
-    <qos_profile name="CSLProfile" is_default_qos="true">
+    <qos_profile name="CSLProfile" is_default_qos="false">
       <!-- QoS used to configure the data writer created in the example code -->
       <datawriter_qos>
         <reliability>

--- a/CIAO/connectors/dds4ccm/tests/CoherentUpdater/descriptors/USER_QOS_PROFILES.xml
+++ b/CIAO/connectors/dds4ccm/tests/CoherentUpdater/descriptors/USER_QOS_PROFILES.xml
@@ -28,7 +28,7 @@ RTI Data Distribution Service user manual.
 
              A QoS profile groups a set of related QoS.
         -->
-    <qos_profile name="CoherentUpdaterProfile" is_default_qos="true">
+    <qos_profile name="CoherentUpdaterProfile" is_default_qos="false">
       <!-- QoS used to configure the data writer created in the example code -->
       <datawriter_qos>
         <reliability>

--- a/CIAO/connectors/dds4ccm/tests/CoherentWriter/descriptors/USER_QOS_PROFILES.xml
+++ b/CIAO/connectors/dds4ccm/tests/CoherentWriter/descriptors/USER_QOS_PROFILES.xml
@@ -28,7 +28,7 @@ RTI Data Distribution Service user manual.
 
              A QoS profile groups a set of related QoS.
         -->
-    <qos_profile name="CoherentWriterProfile" is_default_qos="true">
+    <qos_profile name="CoherentWriterProfile" is_default_qos="false">
       <!-- QoS used to configure the data writer created in the example code -->
       <datawriter_qos>
         <reliability>

--- a/CIAO/connectors/dds4ccm/tests/ContentFilteredTopic/ReadGet/descriptors/USER_QOS_PROFILES.xml
+++ b/CIAO/connectors/dds4ccm/tests/ContentFilteredTopic/ReadGet/descriptors/USER_QOS_PROFILES.xml
@@ -28,7 +28,7 @@ RTI Data Distribution Service user manual.
 
              A QoS profile groups a set of related QoS.
         -->
-    <qos_profile name="QueryConditionProfile" is_default_qos="true">
+    <qos_profile name="QueryConditionProfile" is_default_qos="false">
       <!-- QoS used to configure the data writer created in the example code -->
       <datawriter_qos>
         <reliability>

--- a/CIAO/connectors/dds4ccm/tests/Getter/descriptors/USER_QOS_PROFILES.xml
+++ b/CIAO/connectors/dds4ccm/tests/Getter/descriptors/USER_QOS_PROFILES.xml
@@ -28,7 +28,7 @@ RTI Data Distribution Service user manual.
 
              A QoS profile groups a set of related QoS.
         -->
-    <qos_profile name="GetterProfile" is_default_qos="true">
+    <qos_profile name="GetterProfile" is_default_qos="false">
       <!-- QoS used to configure the data writer created in the example code -->
       <datawriter_qos>
         <reliability>

--- a/CIAO/connectors/dds4ccm/tests/HomeTest/descriptors/USER_QOS_PROFILES.xml
+++ b/CIAO/connectors/dds4ccm/tests/HomeTest/descriptors/USER_QOS_PROFILES.xml
@@ -28,7 +28,7 @@ RTI Data Distribution Service user manual.
 
              A QoS profile groups a set of related QoS.
         -->
-    <qos_profile name="HelloProfile" is_default_qos="true">
+    <qos_profile name="HelloProfile" is_default_qos="false">
       <!-- QoS used to configure the data writer created in the example code -->
       <datawriter_qos>
         <reliability>

--- a/CIAO/connectors/dds4ccm/tests/KeyedWriter/descriptors/USER_QOS_PROFILES.xml
+++ b/CIAO/connectors/dds4ccm/tests/KeyedWriter/descriptors/USER_QOS_PROFILES.xml
@@ -28,7 +28,7 @@ RTI Data Distribution Service user manual.
 
              A QoS profile groups a set of related QoS.
         -->
-    <qos_profile name="KeyedWriterProfile" is_default_qos="true">
+    <qos_profile name="KeyedWriterProfile" is_default_qos="false">
       <!-- QoS used to configure the data writer created in the example code -->
       <datawriter_qos>
         <reliability>

--- a/CIAO/connectors/dds4ccm/tests/LateBinding/ReadGet/descriptors/USER_QOS_PROFILES.xml
+++ b/CIAO/connectors/dds4ccm/tests/LateBinding/ReadGet/descriptors/USER_QOS_PROFILES.xml
@@ -4,7 +4,7 @@
 
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="c:/ndds/ndds.4.5d/scripts/../resource/rtiddsgen/../qos_profiles_4.5d/schema/rti_dds_qos_profiles.xsd" version="4.5d">
   <qos_library name="LateBinding_Library">
-    <qos_profile name="LateBindingProfile" is_default_qos="true">
+    <qos_profile name="LateBindingProfile" is_default_qos="false">
       <datawriter_qos>
         <reliability>
           <kind>RELIABLE_RELIABILITY_QOS</kind>

--- a/CIAO/connectors/dds4ccm/tests/ListenManyByMany/descriptors/USER_QOS_PROFILES.xml
+++ b/CIAO/connectors/dds4ccm/tests/ListenManyByMany/descriptors/USER_QOS_PROFILES.xml
@@ -28,7 +28,7 @@ RTI Data Distribution Service user manual.
 
              A QoS profile groups a set of related QoS.
         -->
-    <qos_profile name="ListenManyByManyProfile" is_default_qos="true">
+    <qos_profile name="ListenManyByManyProfile" is_default_qos="false">
       <!-- QoS used to configure the data writer created in the example code -->
       <datawriter_qos>
         <reliability>

--- a/CIAO/connectors/dds4ccm/tests/PSLDeadline/descriptors/USER_QOS_PROFILES.xml
+++ b/CIAO/connectors/dds4ccm/tests/PSLDeadline/descriptors/USER_QOS_PROFILES.xml
@@ -28,7 +28,7 @@ RTI Data Distribution Service user manual.
 
              A QoS profile groups a set of related QoS.
         -->
-    <qos_profile name="DeadlineProfile" is_default_qos="true">
+    <qos_profile name="DeadlineProfile" is_default_qos="false">
       <!-- QoS used to configure the data writer created in the example code -->
       <datawriter_qos>
         <reliability>

--- a/CIAO/connectors/dds4ccm/tests/PSLSampleLost/descriptors/USER_QOS_PROFILES.xml
+++ b/CIAO/connectors/dds4ccm/tests/PSLSampleLost/descriptors/USER_QOS_PROFILES.xml
@@ -28,7 +28,7 @@ RTI Data Distribution Service user manual.
 
              A QoS profile groups a set of related QoS.
         -->
-    <qos_profile name="HelloProfile" is_default_qos="true">
+    <qos_profile name="HelloProfile" is_default_qos="false">
       <!-- QoS used to configure the data writer created in the example code -->
       <datawriter_qos>
         <reliability>

--- a/CIAO/connectors/dds4ccm/tests/Proxies/ReadWrite/descriptors/USER_QOS_PROFILES.xml
+++ b/CIAO/connectors/dds4ccm/tests/Proxies/ReadWrite/descriptors/USER_QOS_PROFILES.xml
@@ -28,7 +28,7 @@ RTI Data Distribution Service user manual.
 
              A QoS profile groups a set of related QoS.
         -->
-    <qos_profile name="ProxyRWProfile" is_default_qos="true">
+    <qos_profile name="ProxyRWProfile" is_default_qos="false">
       <!-- QoS used to configure the data writer created in the example code -->
       <datawriter_qos>
         <reliability>

--- a/CIAO/connectors/dds4ccm/tests/QosProfile/descriptors/USER_QOS_PROFILES.xml
+++ b/CIAO/connectors/dds4ccm/tests/QosProfile/descriptors/USER_QOS_PROFILES.xml
@@ -4,7 +4,7 @@
 
 <dds xsi:noNamespaceSchemaLocation="c:/ndds/ndds.4.5d/scripts/../resource/rtiddsgen/../qos_profiles_4.5d/schema/rti_dds_qos_profiles.xsd" version="4.5d">
   <qos_library name="QosProfile_Library">
-    <qos_profile name="QosProfileProfile" is_default_qos="true">
+    <qos_profile name="QosProfileProfile" is_default_qos="false">
       <datawriter_qos>
         <reliability>
           <kind>RELIABLE_RELIABILITY_QOS</kind>

--- a/CIAO/connectors/dds4ccm/tests/QueryCondition/DDS/descriptors/USER_QOS_PROFILES.xml
+++ b/CIAO/connectors/dds4ccm/tests/QueryCondition/DDS/descriptors/USER_QOS_PROFILES.xml
@@ -30,7 +30,7 @@ RTI Data Distribution Service user manual.
 
              A QoS profile groups a set of related QoS.
         -->
-    <qos_profile name="QueryConditionProfile" is_default_qos="true">
+    <qos_profile name="QueryConditionProfile" is_default_qos="false">
       <!-- QoS used to configure the data writer created in the example code -->
       <datawriter_qos>
         <reliability>

--- a/CIAO/connectors/dds4ccm/tests/QueryCondition/DDS_OneByOne/descriptors/USER_QOS_PROFILES.xml
+++ b/CIAO/connectors/dds4ccm/tests/QueryCondition/DDS_OneByOne/descriptors/USER_QOS_PROFILES.xml
@@ -30,7 +30,7 @@ RTI Data Distribution Service user manual.
 
              A QoS profile groups a set of related QoS.
         -->
-    <qos_profile name="QueryConditionProfile" is_default_qos="true">
+    <qos_profile name="QueryConditionProfile" is_default_qos="false">
       <!-- QoS used to configure the data writer created in the example code -->
       <datawriter_qos>
         <reliability>

--- a/CIAO/connectors/dds4ccm/tests/QueryCondition/Different/descriptors/USER_QOS_PROFILES.xml
+++ b/CIAO/connectors/dds4ccm/tests/QueryCondition/Different/descriptors/USER_QOS_PROFILES.xml
@@ -28,7 +28,7 @@ RTI Data Distribution Service user manual.
 
              A QoS profile groups a set of related QoS.
         -->
-    <qos_profile name="QueryConditionProfile" is_default_qos="true">
+    <qos_profile name="QueryConditionProfile" is_default_qos="false">
       <!-- QoS used to configure the data writer created in the example code -->
       <datawriter_qos>
         <reliability>

--- a/CIAO/connectors/dds4ccm/tests/QueryCondition/ReadGet/descriptors/USER_QOS_PROFILES.xml
+++ b/CIAO/connectors/dds4ccm/tests/QueryCondition/ReadGet/descriptors/USER_QOS_PROFILES.xml
@@ -28,7 +28,7 @@ RTI Data Distribution Service user manual.
 
              A QoS profile groups a set of related QoS.
         -->
-    <qos_profile name="QueryConditionProfile" is_default_qos="true">
+    <qos_profile name="QueryConditionProfile" is_default_qos="false">
       <!-- QoS used to configure the data writer created in the example code -->
       <datawriter_qos>
         <reliability>

--- a/CIAO/connectors/dds4ccm/tests/QueryCondition/TwoQueries/descriptors/USER_QOS_PROFILES.xml
+++ b/CIAO/connectors/dds4ccm/tests/QueryCondition/TwoQueries/descriptors/USER_QOS_PROFILES.xml
@@ -28,7 +28,7 @@ RTI Data Distribution Service user manual.
 
              A QoS profile groups a set of related QoS.
         -->
-    <qos_profile name="QueryConditionProfile" is_default_qos="true">
+    <qos_profile name="QueryConditionProfile" is_default_qos="false">
       <!-- QoS used to configure the data writer created in the example code -->
       <datawriter_qos>
         <reliability>

--- a/CIAO/connectors/dds4ccm/tests/QueryCondition/TwoQueriesMany/descriptors/USER_QOS_PROFILES.xml
+++ b/CIAO/connectors/dds4ccm/tests/QueryCondition/TwoQueriesMany/descriptors/USER_QOS_PROFILES.xml
@@ -28,7 +28,7 @@ RTI Data Distribution Service user manual.
 
              A QoS profile groups a set of related QoS.
         -->
-    <qos_profile name="QueryConditionProfile" is_default_qos="true">
+    <qos_profile name="QueryConditionProfile" is_default_qos="false">
       <!-- QoS used to configure the data writer created in the example code -->
       <datawriter_qos>
         <reliability>

--- a/CIAO/connectors/dds4ccm/tests/Reader/descriptors/USER_QOS_PROFILES.xml
+++ b/CIAO/connectors/dds4ccm/tests/Reader/descriptors/USER_QOS_PROFILES.xml
@@ -28,7 +28,7 @@ RTI Data Distribution Service user manual.
 
              A QoS profile groups a set of related QoS.
         -->
-    <qos_profile name="ReaderProfile" is_default_qos="true">
+    <qos_profile name="ReaderProfile" is_default_qos="false">
       <!-- QoS used to configure the data writer created in the example code -->
       <datawriter_qos>
         <reliability>

--- a/CIAO/connectors/dds4ccm/tests/ResetTopic/ReadGet/descriptors/USER_QOS_PROFILES.xml
+++ b/CIAO/connectors/dds4ccm/tests/ResetTopic/ReadGet/descriptors/USER_QOS_PROFILES.xml
@@ -2,7 +2,7 @@
 <!--  -->
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="c:/ndds/ndds.4.5d/scripts/../resource/rtiddsgen/../qos_profiles_4.5d/schema/rti_dds_qos_profiles.xsd" version="4.5d">
   <qos_library name="ResetTopic_Library">
-    <qos_profile name="ResetTopicProfile" is_default_qos="true">
+    <qos_profile name="ResetTopicProfile" is_default_qos="false">
       <datawriter_qos>
         <reliability>
           <kind>RELIABLE_RELIABILITY_QOS</kind>

--- a/CIAO/connectors/dds4ccm/tests/SLManyByMany/descriptors/USER_QOS_PROFILES.xml
+++ b/CIAO/connectors/dds4ccm/tests/SLManyByMany/descriptors/USER_QOS_PROFILES.xml
@@ -28,7 +28,7 @@ RTI Data Distribution Service user manual.
 
              A QoS profile groups a set of related QoS.
         -->
-    <qos_profile name="SlMbMProfile" is_default_qos="true">
+    <qos_profile name="SlMbMProfile" is_default_qos="false">
       <!-- QoS used to configure the data writer created in the example code -->
       <datawriter_qos>
         <reliability>

--- a/CIAO/connectors/dds4ccm/tests/SLOneByOne/descriptors/USER_QOS_PROFILES.xml
+++ b/CIAO/connectors/dds4ccm/tests/SLOneByOne/descriptors/USER_QOS_PROFILES.xml
@@ -28,7 +28,7 @@ RTI Data Distribution Service user manual.
 
              A QoS profile groups a set of related QoS.
         -->
-    <qos_profile name="SlObOProfile" is_default_qos="true">
+    <qos_profile name="SlObOProfile" is_default_qos="false">
       <!-- QoS used to configure the data writer created in the example code -->
       <datawriter_qos>
         <reliability>

--- a/CIAO/connectors/dds4ccm/tests/SharedDomainParticipant/DifferentDatatype/descriptors/USER_QOS_PROFILES.xml
+++ b/CIAO/connectors/dds4ccm/tests/SharedDomainParticipant/DifferentDatatype/descriptors/USER_QOS_PROFILES.xml
@@ -4,7 +4,7 @@
 
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="c:/ndds/ndds.4.5d/scripts/../resource/rtiddsgen/../qos_profiles_4.5d/schema/rti_dds_qos_profiles.xsd" version="4.5d">
   <qos_library name="Shared_Library">
-    <qos_profile name="SharedProfile" is_default_qos="true">
+    <qos_profile name="SharedProfile" is_default_qos="false">
       <datawriter_qos>
         <reliability>
           <kind>RELIABLE_RELIABILITY_QOS</kind>
@@ -41,7 +41,7 @@
     </qos_profile>
   </qos_library>
   <qos_library name="Standalone_Library">
-    <qos_profile name="StandaloneProfile" is_default_qos="true">
+    <qos_profile name="StandaloneProfile" is_default_qos="false">
       <datawriter_qos>
         <reliability>
           <kind>RELIABLE_RELIABILITY_QOS</kind>

--- a/CIAO/connectors/dds4ccm/tests/SharedDomainParticipant/DifferentDomainID/descriptors/USER_QOS_PROFILES.xml
+++ b/CIAO/connectors/dds4ccm/tests/SharedDomainParticipant/DifferentDomainID/descriptors/USER_QOS_PROFILES.xml
@@ -4,7 +4,7 @@
 
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="c:/ndds/ndds.4.5d/scripts/../resource/rtiddsgen/../qos_profiles_4.5d/schema/rti_dds_qos_profiles.xsd" version="4.5d">
   <qos_library name="Shared_Library">
-    <qos_profile name="SharedProfile" is_default_qos="true">
+    <qos_profile name="SharedProfile" is_default_qos="false">
       <datawriter_qos>
         <reliability>
           <kind>RELIABLE_RELIABILITY_QOS</kind>
@@ -41,7 +41,7 @@
     </qos_profile>
   </qos_library>
   <qos_library name="Standalone_Library">
-    <qos_profile name="StandaloneProfile" is_default_qos="true">
+    <qos_profile name="StandaloneProfile" is_default_qos="false">
       <datawriter_qos>
         <reliability>
           <kind>RELIABLE_RELIABILITY_QOS</kind>

--- a/CIAO/connectors/dds4ccm/tests/SharedDomainParticipant/SameDatatype/descriptors/USER_QOS_PROFILES.xml
+++ b/CIAO/connectors/dds4ccm/tests/SharedDomainParticipant/SameDatatype/descriptors/USER_QOS_PROFILES.xml
@@ -4,7 +4,7 @@
 
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="c:/ndds/ndds.4.5d/scripts/../resource/rtiddsgen/../qos_profiles_4.5d/schema/rti_dds_qos_profiles.xsd" version="4.5d">
   <qos_library name="Shared_Library">
-    <qos_profile name="SharedProfile" is_default_qos="true">
+    <qos_profile name="SharedProfile" is_default_qos="false">
       <datawriter_qos>
         <reliability>
           <kind>RELIABLE_RELIABILITY_QOS</kind>
@@ -41,7 +41,7 @@
     </qos_profile>
   </qos_library>
   <qos_library name="Standalone_Library">
-    <qos_profile name="StandaloneProfile" is_default_qos="true">
+    <qos_profile name="StandaloneProfile" is_default_qos="false">
       <datawriter_qos>
         <reliability>
           <kind>RELIABLE_RELIABILITY_QOS</kind>

--- a/CIAO/connectors/dds4ccm/tests/UnkeyedWriter/descriptors/USER_QOS_PROFILES.xml
+++ b/CIAO/connectors/dds4ccm/tests/UnkeyedWriter/descriptors/USER_QOS_PROFILES.xml
@@ -28,7 +28,7 @@ RTI Data Distribution Service user manual.
 
              A QoS profile groups a set of related QoS.
         -->
-    <qos_profile name="UnkeyedWriterProfile" is_default_qos="true">
+    <qos_profile name="UnkeyedWriterProfile" is_default_qos="false">
       <!-- QoS used to configure the data writer created in the example code -->
       <datawriter_qos>
         <reliability>

--- a/DAnCE/tools/Logger_Backend/ndds/USER_QOS_PROFILES.xml
+++ b/DAnCE/tools/Logger_Backend/ndds/USER_QOS_PROFILES.xml
@@ -2,7 +2,7 @@
 <!-- Default QoS specification for NDDS logger. -->
 <dds>
   <qos_library name="DAnCE">
-    <qos_profile name="Logger" is_default_qos="true">
+    <qos_profile name="Logger" is_default_qos="false">
       <topic_qos name="DAnCELogging">
         <reliability>
           <kind>RELIABLE_RELIABILITY_QOS</kind>


### PR DESCRIPTION
...tring in the deployment

plan. Since this is consistently done, we can set the is_default_qos to false.

    * CIAO/connectors/dds4ccm/examples/IDL2CPPWrapper/Shapes/descriptors/USER_QOS_PROFILES.xml:
    * CIAO/connectors/dds4ccm/examples/ShapesContr/descriptors/USER_QOS_PROFILES.xml:
    * CIAO/connectors/dds4ccm/performance-tests/DDSLatency/descriptors/USER_QOS_PROFILES.xml:
    * CIAO/connectors/dds4ccm/performance-tests/DDSThroughput/descriptors/USER_QOS_PROFILES.xml:
    * CIAO/connectors/dds4ccm/performance-tests/Keyed/descriptors/USER_QOS_PROFILES.xml:
    * CIAO/connectors/dds4ccm/performance-tests/Latency/descriptors/USER_QOS_PROFILES.xml:
    * CIAO/connectors/dds4ccm/performance-tests/Throughput/descriptors/USER_QOS_PROFILES.xml:
    * CIAO/connectors/dds4ccm/tests/CSLDeadline/descriptors/USER_QOS_PROFILES.xml:
    * CIAO/connectors/dds4ccm/tests/CSLQoS/descriptors/USER_QOS_PROFILES.xml:
    * CIAO/connectors/dds4ccm/tests/CSLSampleRejected/descriptors/USER_QOS_PROFILES.xml:
    * CIAO/connectors/dds4ccm/tests/CSLUnexpStat/descriptors/USER_QOS_PROFILES.xml:
    * CIAO/connectors/dds4ccm/tests/CoherentUpdater/descriptors/USER_QOS_PROFILES.xml:
    * CIAO/connectors/dds4ccm/tests/CoherentWriter/descriptors/USER_QOS_PROFILES.xml:
    * CIAO/connectors/dds4ccm/tests/ContentFilteredTopic/ReadGet/descriptors/USER_QOS_PROFILES.xml:
    * CIAO/connectors/dds4ccm/tests/Getter/descriptors/USER_QOS_PROFILES.xml:
    * CIAO/connectors/dds4ccm/tests/HomeTest/descriptors/USER_QOS_PROFILES.xml:
    * CIAO/connectors/dds4ccm/tests/KeyedWriter/descriptors/USER_QOS_PROFILES.xml:
    * CIAO/connectors/dds4ccm/tests/LateBinding/ReadGet/descriptors/USER_QOS_PROFILES.xml:
    * CIAO/connectors/dds4ccm/tests/ListenManyByMany/descriptors/USER_QOS_PROFILES.xml:
    * CIAO/connectors/dds4ccm/tests/PSLDeadline/descriptors/USER_QOS_PROFILES.xml:
    * CIAO/connectors/dds4ccm/tests/PSLSampleLost/descriptors/USER_QOS_PROFILES.xml:
    * CIAO/connectors/dds4ccm/tests/Proxies/ReadWrite/descriptors/USER_QOS_PROFILES.xml:
    * CIAO/connectors/dds4ccm/tests/QosProfile/descriptors/USER_QOS_PROFILES.xml:
    * CIAO/connectors/dds4ccm/tests/QueryCondition/DDS/descriptors/USER_QOS_PROFILES.xml:
    * CIAO/connectors/dds4ccm/tests/QueryCondition/DDS_OneByOne/descriptors/USER_QOS_PROFILES.xml:
    * CIAO/connectors/dds4ccm/tests/QueryCondition/Different/descriptors/USER_QOS_PROFILES.xml:
    * CIAO/connectors/dds4ccm/tests/QueryCondition/ReadGet/descriptors/USER_QOS_PROFILES.xml:
    * CIAO/connectors/dds4ccm/tests/QueryCondition/TwoQueries/descriptors/USER_QOS_PROFILES.xml:
    * CIAO/connectors/dds4ccm/tests/QueryCondition/TwoQueriesMany/descriptors/USER_QOS_PROFILES.xml:
    * CIAO/connectors/dds4ccm/tests/Reader/descriptors/USER_QOS_PROFILES.xml:
    * CIAO/connectors/dds4ccm/tests/ResetTopic/ReadGet/descriptors/USER_QOS_PROFILES.xml:
    * CIAO/connectors/dds4ccm/tests/SLManyByMany/descriptors/USER_QOS_PROFILES.xml:
    * CIAO/connectors/dds4ccm/tests/SLOneByOne/descriptors/USER_QOS_PROFILES.xml:
    * CIAO/connectors/dds4ccm/tests/SharedDomainParticipant/DifferentDatatype/descriptors/USER_QOS_PROFILES.xml:
    * CIAO/connectors/dds4ccm/tests/SharedDomainParticipant/DifferentDomainID/descriptors/USER_QOS_PROFILES.xml:
    * CIAO/connectors/dds4ccm/tests/SharedDomainParticipant/SameDatatype/descriptors/USER_QOS_PROFILES.xml:
    * CIAO/connectors/dds4ccm/tests/UnkeyedWriter/descriptors/USER_QOS_PROFILES.xml:
    * DAnCE/tools/Logger_Backend/ndds/USER_QOS_PROFILES.xml: