### PR TITLE
Fix errno checking logic in TLI

### DIFF
--- a/ACE/ace/ACE.cpp
+++ b/ACE/ace/ACE.cpp
@@ -1529,7 +1529,7 @@ ACE::t_snd_n_i (ACE_HANDLE handle,
         {
           // Check for possible blocking.
           if (n == -1 &&
-              errno == EWOULDBLOCK || errno == ENOBUFS)
+              (errno == EWOULDBLOCK || errno == ENOBUFS))
             {
               // Wait upto <timeout> for the blocking to subside.
               int const rtn = ACE::handle_write_ready (handle, timeout);


### PR DESCRIPTION
When building in AIX 5.1, GCC reported

```
ACE.cpp: In function 'ssize_t ACE::t_snd_n_i(ACE_HANDLE, const void*, size_t, int, const ACE_Time_Value*, size_t*)':
ACE.cpp:1532:39: warning: suggest parentheses around '&&' within '||'
```

After reading ACE.cpp, I find it is not only a warning but also a bug.