### PR TITLE
ACE_Addr::set_addr(void*, int) was changed to ACE_Addr::set_addr(const v...

### DIFF
--- a/ACE/NEWS
+++ b/ACE/NEWS
@@ -19,6 +19,14 @@ USER VISIBLE CHANGES BETWEEN ACE-6.3.1 and ACE-6.3.2
   ACE_Multihomed_INET_Addr has also been enhanced so that the get_addresses()
   methods copy all available addresses related to each name.
 
+. The ACE_Addr::set_addr (void*, int) signature was changed to
+  ACE_Addr::set_addr (const void*, int). All classes that inherit from
+  ACE_Addr also have the same change. This affects ACE_ATM_Addr, ACE_Addr,
+  ACE_INET_Addr, ACE_MEM_Addr, ACE_Netlink_Addr, ACE_SPIPE_Addr, ACE_UNIX_Addr.
+  Any user-written classes derived from ACE_Addr will also need to change to
+  match the new signature for virtual method dispatch to continue working
+  properly in all cases.
+
 USER VISIBLE CHANGES BETWEEN ACE-6.3.0 and ACE-6.3.1
 ====================================================
 

--- a/ACE/ace/ATM_Addr.cpp
+++ b/ACE/ace/ATM_Addr.cpp
@@ -450,7 +450,7 @@ ACE_ATM_Addr::addr_to_string (void) const
 
 // Set a pointer to the address.
 void
-ACE_ATM_Addr::set_addr (void *addr, int len)
+ACE_ATM_Addr::set_addr (const void *addr, int len)
 {
   ACE_TRACE ("ACE_ATM_Addr::set_addr");
 
@@ -462,8 +462,7 @@ ACE_ATM_Addr::set_addr (void *addr, int len)
   this->ACE_Addr::base_set (AF_UNSPEC,
 #endif /* ACE_HAS_FORE_ATM_XTI || ACE_HAS_FORE_WS2 */
                             len);
-  ACE_OS::memcpy ((void *) &this->atm_addr_,
- (void *) addr, len);
+  ACE_OS::memcpy (&this->atm_addr_, addr, len);
 }
 
 // Compare two addresses for inequality.

--- a/ACE/ace/ATM_Addr.h
+++ b/ACE/ace/ATM_Addr.h
@@ -148,7 +148,7 @@ public:
   virtual void *get_addr (void) const;
 
   /// Set a pointer to the address.
-  virtual void set_addr (void *, int);
+  virtual void set_addr (const void *, int);
 
   /// Return the selector for network address.
   u_char get_selector (void) const;

--- a/ACE/ace/Addr.cpp
+++ b/ACE/ace/Addr.cpp
@@ -36,7 +36,7 @@ ACE_Addr::get_addr (void) const
 }
 
 void
-ACE_Addr::set_addr (void *, int)
+ACE_Addr::set_addr (const void *, int)
 {
 }
 

--- a/ACE/ace/Addr.h
+++ b/ACE/ace/Addr.h
@@ -57,7 +57,7 @@ public:
   virtual void *get_addr (void) const;
 
   /// Set a pointer to the address.
-  virtual void set_addr (void *, int len);
+  virtual void set_addr (const void *, int len);
 
   // = Equality/inequality tests
   /// Check for address equality.

--- a/ACE/ace/INET_Addr.cpp
+++ b/ACE/ace/INET_Addr.cpp
@@ -1050,9 +1050,6 @@ int ACE_INET_Addr::set_address (const char *ip_addr,
         }
 #endif /* ACE_HAS_IPV6 */
 
-      this->inet_addrs_.clear ();
-      this->inet_addrs_iter_ = this->inet_addrs_.begin ();
-
       return 0;
     }   /* end if (len == 4) */
 #if defined (ACE_HAS_IPV6)
@@ -1070,9 +1067,6 @@ int ACE_INET_Addr::set_address (const char *ip_addr,
       this->inet_addr_.in6_.sin6_len = sizeof (this->inet_addr_.in6_);
 #endif
       ACE_OS::memcpy (&this->inet_addr_.in6_.sin6_addr, ip_addr, len);
-      this->inet_addrs_.clear ();
-      this->inet_addrs_iter_ = this->inet_addrs_.begin ();
-
       return 0;
     } /* end len == 16 */
 #endif /* ACE_HAS_IPV6 */

--- a/ACE/ace/MEM_Addr.cpp
+++ b/ACE/ace/MEM_Addr.cpp
@@ -115,7 +115,7 @@ ACE_MEM_Addr::get_addr (void) const
 
 // Set a pointer to the address.
 void
-ACE_MEM_Addr::set_addr (void *addr, int len)
+ACE_MEM_Addr::set_addr (const void *addr, int len)
 {
   ACE_TRACE ("ACE_MEM_Addr::set_addr");
 

--- a/ACE/ace/MEM_Addr.h
+++ b/ACE/ace/MEM_Addr.h
@@ -76,7 +76,7 @@ public:
   virtual void *get_addr (void) const;
 
   /// Set a pointer to the address.
-  virtual void set_addr (void *, int len);
+  virtual void set_addr (const void *, int len);
 
   /// Transform the external ACE_MEM_Addr address into string
   /// format.

--- a/ACE/ace/Netlink_Addr.h
+++ b/ACE/ace/Netlink_Addr.h
@@ -81,7 +81,7 @@ public:
   /**
    * Set a pointer to the address
    */
-  virtual void set_addr (void *, int len= sizeof(sockaddr_nl) );
+  virtual void set_addr (const void *, int len= sizeof(sockaddr_nl) );
 
   /// Declare the dynamic allocation hooks.
   ACE_ALLOC_HOOK_DECLARE;

--- a/ACE/ace/Netlink_Addr.inl
+++ b/ACE/ace/Netlink_Addr.inl
@@ -39,8 +39,8 @@ ACE_INLINE int ACE_Netlink_Addr::get_addr_size (void) const
 }
 
 
-ACE_INLINE void ACE_Netlink_Addr::set_addr (void *addr, int len){
-  ACE_OS::memcpy (&this->nl_,addr,len);
+ACE_INLINE void ACE_Netlink_Addr::set_addr (const void *addr, int len) {
+  ACE_OS::memcpy (&this->nl_, addr, len);
 }
 
 ACE_END_VERSIONED_NAMESPACE_DECL

--- a/ACE/ace/SPIPE_Addr.cpp
+++ b/ACE/ace/SPIPE_Addr.cpp
@@ -22,14 +22,12 @@ ACE_SPIPE_Addr::dump (void) const
 
 // Set a pointer to the address.
 void
-ACE_SPIPE_Addr::set_addr (void *addr, int len)
+ACE_SPIPE_Addr::set_addr (const void *addr, int len)
 {
   ACE_TRACE ("ACE_SPIPE_Addr::set_addr");
 
   this->ACE_Addr::base_set (AF_SPIPE, len);
-  ACE_OS::memcpy ((void *) &this->SPIPE_addr_,
-                  (void *) addr,
-                  len);
+  ACE_OS::memcpy (&this->SPIPE_addr_, addr, len);
 }
 
 // Return the address.

--- a/ACE/ace/SPIPE_Addr.h
+++ b/ACE/ace/SPIPE_Addr.h
@@ -55,7 +55,7 @@ public:
   virtual void *get_addr (void) const;
 
   /// Set a pointer to the underlying network address.
-  virtual void set_addr (void *addr, int len);
+  virtual void set_addr (const void *addr, int len);
 
   /// Transform the current address into string format.
   virtual int addr_to_string (ACE_TCHAR *addr, size_t) const;

--- a/ACE/ace/UNIX_Addr.cpp
+++ b/ACE/ace/UNIX_Addr.cpp
@@ -14,14 +14,12 @@ ACE_ALLOC_HOOK_DEFINE(ACE_UNIX_Addr)
 
 // Set a pointer to the address.
 void
-ACE_UNIX_Addr::set_addr (void *addr, int len)
+ACE_UNIX_Addr::set_addr (const void *addr, int len)
 {
   ACE_TRACE ("ACE_UNIX_Addr::set_addr");
 
   this->ACE_Addr::base_set (AF_UNIX, len);
-  ACE_OS::memcpy ((void *) &this->unix_addr_,
-                  (void *) addr,
-                  len);
+  ACE_OS::memcpy (&this->unix_addr_, addr, len);
 }
 
 // Return a pointer to the underlying address.

--- a/ACE/ace/UNIX_Addr.h
+++ b/ACE/ace/UNIX_Addr.h
@@ -63,7 +63,7 @@ public:
   virtual void *get_addr (void) const;
 
   /// Set a pointer to the underlying network address.
-  virtual void set_addr (void *addr, int len);
+  virtual void set_addr (const void *addr, int len);
 
   /// Transform the current address into string format.
   virtual int addr_to_string (ACE_TCHAR addr[], size_t) const;

--- a/ACE/tests/INET_Addr_Test.cpp
+++ b/ACE/tests/INET_Addr_Test.cpp
@@ -271,11 +271,14 @@ int run_main (int, ACE_TCHAR *[])
 
           if (0 != ACE_OS::strcmp (addr.get_host_name (), ipv6_names[i]))
             {
-              ACE_ERROR ((LM_WARNING,
-                          ACE_TEXT ("IPv6 name mismatch: %s (%s) != %s\n"),
-                          addr.get_host_name (),
-                          addr.get_host_addr (),
-                          ipv6_names[i]));
+              // Alias? Check lookup on the reverse.
+              ACE_INET_Addr alias_check (80, addr.get_host_name ());
+              if (addr != alias_check)
+                ACE_ERROR ((LM_WARNING,
+                            ACE_TEXT ("IPv6 name mismatch: %s (%s) != %s\n"),
+                            addr.get_host_name (),
+                            addr.get_host_addr (),
+                            ipv6_names[i]));
             }
         }
     }


### PR DESCRIPTION
...oid*, int). All descendant classes have the same change. Fixed multiple-address handling in ACE_INET_Addr and check for alias in INET_Addr_Test if a hostname reverse lookup doesn't match the forward lookup.