### PR TITLE
Header output extension should be optional

### DIFF
--- a/TAO/MPC/config/taobaseidldefaults.mpb
+++ b/TAO/MPC/config/taobaseidldefaults.mpb
@@ -16,7 +16,10 @@ project: build_files {
     libpath              = $(ACE_ROOT)/lib
     inputext             = .idl
     keyword idlflags     = commandflags
-    header_outputext = .h, .hpp, .hxx, .hh
+
+    optional(header_outputext) {
+      commandflags(!-Sch && !-Ssh) = .h, .hpp, .hxx, .hh
+    }
 
     optional(source_pre_extension) {
       commandflags(!-Scc) = C
@@ -45,9 +48,6 @@ project: build_files {
     }
 
     // Header related options
-    optional(header_outputext) {
-      commandflags(-SS && !-oS && !-Ssh) += S
-    }
     optional(header_pre_extension) {
       commandflags(!-oS && !-Ssh) += S
     }

--- a/TAO/MPC/config/taobaseidldefaults.mpb
+++ b/TAO/MPC/config/taobaseidldefaults.mpb
@@ -18,7 +18,7 @@ project: build_files {
     keyword idlflags     = commandflags
 
     optional(header_outputext) {
-      commandflags(!-Sch && !-Ssh) = .h, .hpp, .hxx, .hh
+      commandflags(!-Sch || !-Ssh) = .h, .hpp, .hxx, .hh
     }
 
     optional(source_pre_extension) {
@@ -28,7 +28,7 @@ project: build_files {
       commandflags(!-Sch) = C
     }
     optional(source_outputext) {
-      commandflags(!-Scc && !-Ssc) = .cpp, .cxx, .cc, .C
+      commandflags(!-Scc || !-Ssc) = .cpp, .cxx, .cc, .C
     }
 
     // Inline related options


### PR DESCRIPTION
Header output extension should be optional otherwise the make files always has an header included. This goes wrong when only an IDL file is created by the R/TAO IDL compiler.