### PR TITLE
fix compile error for ssl (MAXHOSTNAMELEN missing)

### DIFF
--- a/ACE/ace/SSL/SSL_Context.cpp
+++ b/ACE/ace/SSL/SSL_Context.cpp
@@ -17,6 +17,7 @@
 #include "ace/OS_NS_errno.h"
 #include "ace/OS_NS_string.h"
 #include "ace/OS_NS_ctype.h"
+#include "ace/OS_NS_netdb.h"
 
 #ifdef ACE_HAS_THREADS
 # include "ace/Thread_Mutex.h"


### PR DESCRIPTION
version information : 
msvc community 2013 / ace (github DocGroup/ATCD master) / openssl 1.0.2a / zlib 1.2.8
