### PR TITLE
Thread pool bugfixes

### DIFF
--- a/TAO/tao/CSD_ThreadPool/CSD_TP_Task.cpp
+++ b/TAO/tao/CSD_ThreadPool/CSD_TP_Task.cpp
@@ -46,7 +46,6 @@ int
 TAO::CSD::TP_Task::open(void* args)
 {
   Thread_Counter num = 1;
-
   Thread_Counter* tmp = static_cast<Thread_Counter*> (args);
 
   if (tmp == 0)
@@ -71,30 +70,14 @@ TAO::CSD::TP_Task::open(void* args)
                        -1);
     }
 
-  // Likewise, we can't activate too many.  Make sure this isn't the case.
-  if (num > MAX_THREADPOOL_TASK_WORKER_THREADS)
-    {
-      TAOLIB_ERROR_RETURN((LM_ERROR,
-                        ACE_TEXT ("(%P|%t) TP_Task failed to open.  ")
-                        ACE_TEXT ("num_threads (%u) is too large.  ")
-                        ACE_TEXT ("Max is %d.\n"),
-                        num, MAX_THREADPOOL_TASK_WORKER_THREADS),
-                        -1);
-    }
-
   // We need the lock acquired from here on out.
   ACE_GUARD_RETURN (TAO_SYNCH_MUTEX, guard, this->lock_, -1);
 
-  // We can assume that we are in the proper state to handle this open()
-  // call as long as we haven't been open()'ed before.
+  // Multiple POA_Manager::activate() calls trigger multiple calls to open()
+  // and that is OK
   if (this->opened_)
     {
-      //FUZZ: disable check_for_lack_ACE_OS
-      TAOLIB_ERROR_RETURN((LM_ERROR,
-                        ACE_TEXT ("(%P|%t) TP_Task failed to open.  ")
-                        ACE_TEXT ("Task has previously been open()'ed.\n")),
-                       -1);
-      //FUZZ: enable check_for_lack_ACE_OS
+      return 0;
     }
 
   // Activate this task object with 'num' worker threads.

--- a/TAO/tao/Dynamic_TP/DTP_Thread_Pool.cpp
+++ b/TAO/tao/Dynamic_TP/DTP_Thread_Pool.cpp
@@ -344,12 +344,24 @@ TAO_DTP_Thread_Pool::create_threads_i (size_t count)
                                default_thread_handles,
                                default_stack,
                                stack_size_array);
-    if (TAO_debug_level > 7)
+    if (result == 0)
       {
-        TAOLIB_DEBUG ((LM_DEBUG,
-                       ACE_TEXT ("TAO (%P|%t) new DTP thread requester waiting\n")));
+        if (TAO_debug_level > 7)
+          {
+            TAOLIB_DEBUG ((LM_DEBUG,
+                           ACE_TEXT ("TAO (%P|%t) new DTP thread requester waiting\n")));
+          }
+        this->activation_cond_.wait ();
       }
-    this->activation_cond_.wait ();
+    else
+      {
+        if (TAO_debug_level > 0)
+          {
+            TAOLIB_ERROR ((LM_ERROR,
+                           ACE_TEXT ("TAO (%P|%t) new DTP thread failed %p\n"),
+                           ACE_TEXT ("ACE_Task_Base::activate")));
+          }
+      }
   }
   if (TAO_debug_level > 7)
     {


### PR DESCRIPTION
relax limits on fixed POA pool size.
Ensure the dynamic thread activation succeeded before entering wait