### PR TITLE
Added support to schedule and reset timers using std::chrono::duratio…

### DIFF
--- a/ACE/ace/Reactor.h
+++ b/ACE/ace/Reactor.h
@@ -578,7 +578,19 @@ public:
                                const ACE_Time_Value &delay,
                                const ACE_Time_Value &interval =
                                 ACE_Time_Value::zero);
-
+#if defined (ACE_HAS_CPP11)
+  template<class Rep1, class Period1, class Rep2 = int, class Period2 = std::ratio<1>>
+  long schedule_timer (ACE_Event_Handler *event_handler,
+                       const void *arg,
+                       const std::chrono::duration<Rep1, Period1>& delay,
+                       const std::chrono::duration<Rep2, Period2>& interval =
+                        std::chrono::duration<Rep2, Period2>::zero ())
+  {
+    ACE_Time_Value const tv_delay (delay);
+    ACE_Time_Value const tv_interval (interval);
+    return this->schedule_timer (event_handler, arg, tv_delay, tv_interval);
+  }
+#endif
   /**
    * Reset recurring timer interval.
    *
@@ -592,6 +604,15 @@ public:
    */
   virtual int reset_timer_interval (long timer_id,
                                     const ACE_Time_Value &interval);
+#if defined (ACE_HAS_CPP11)
+  template<class Rep, class Period>
+  int reset_timer_interval (long timer_id,
+                            const std::chrono::duration<Rep, Period>& interval)
+  {
+    ACE_Time_Value const tv_interval (interval);
+    return this->reset_timer_interval (timer_id, tv_interval);
+  }
+#endif
 
   /**
    * Cancel timer.

--- a/ACE/ace/Reactor_Timer_Interface.h
+++ b/ACE/ace/Reactor_Timer_Interface.h
@@ -31,7 +31,6 @@ class ACE_Event_Handler;
 class ACE_Export ACE_Reactor_Timer_Interface
 {
 public:
-
   virtual ~ACE_Reactor_Timer_Interface (void);
 
   virtual long schedule_timer (ACE_Event_Handler *event_handler,
@@ -39,8 +38,30 @@ public:
                                const ACE_Time_Value &delay,
                                const ACE_Time_Value &interval = ACE_Time_Value::zero) = 0;
 
+#if defined (ACE_HAS_CPP11)
+  template<class Rep1, class Period1, class Rep2 = int, class Period2 = std::ratio<1>>
+  long schedule_timer (ACE_Event_Handler *event_handler,
+                       const void *arg,
+                       const std::chrono::duration<Rep1, Period1>& delay,
+                       const std::chrono::duration<Rep2, Period2>& interval = std::chrono::duration<Rep2, Period2>::zero ())
+  {
+    ACE_Time_Value const tv_delay (delay);
+    ACE_Time_Value const tv_interval (interval);
+    return this->schedule_timer (event_handler, arg, tv_delay, tv_interval);
+  }
+#endif
+
   virtual int reset_timer_interval (long timer_id,
                                     const ACE_Time_Value &interval) = 0;
+#if defined (ACE_HAS_CPP11)
+  template<class Rep, class Period>
+  int reset_timer_interval (long timer_id,
+                            const std::chrono::duration<Rep, Period>& interval)
+  {
+    ACE_Time_Value const tv_interval (interval);
+    return this->reset_timer_interval (timer_id, tv_interval);
+  }
+#endif
 
   virtual int cancel_timer (long timer_id,
                             const void **arg = 0,

--- a/ACE/tests/Reactor_Timer_Test.cpp
+++ b/ACE/tests/Reactor_Timer_Test.cpp
@@ -98,8 +98,13 @@ Time_Handler::handle_timeout (const ACE_Time_Value &tv,
     }
   else if (current_count == -1)
     {
+#if defined (ACE_HAS_CPP11)
+      int result = ACE_Reactor::instance ()->reset_timer_interval (this->timer_id (),
+                                                                   std::chrono::seconds {the_count + 1});
+#else
       int result = ACE_Reactor::instance ()->reset_timer_interval (this->timer_id (),
                                                                    ACE_Time_Value (the_count + 1));
+#endif
       if (result == -1)
         ACE_ERROR ((LM_ERROR,
                     ACE_TEXT ("Error resetting timer interval\n")));
@@ -132,9 +137,15 @@ test_registering_all_handlers (void)
   for (size_t i = 0; i < ACE_MAX_TIMERS; i++)
     {
       t_id[i] =
+#if defined (ACE_HAS_CPP11)
+        ACE_Reactor::instance ()->schedule_timer (&rt[i],
+                                                  (const void *) i,
+                                                  std::chrono::seconds {2 * i + 1});
+#else
         ACE_Reactor::instance ()->schedule_timer (&rt[i],
                                                   (const void *) i,
                                                   ACE_Time_Value (2 * i + 1));
+#endif
       ACE_TEST_ASSERT (t_id[i] != -1);
       rt[i].timer_id (t_id[i]);
     }


### PR DESCRIPTION
…n at the moment C++11 support is available

    * ACE/ace/Reactor.h:
    * ACE/ace/Reactor_Timer_Interface.h:
    * ACE/tests/Reactor_Timer_Test.cpp: