### PR TITLE
Honor '-Cw' flag passed to tao_idl

### DIFF
--- a/TAO/TAO_IDL/util/utl_scope.cpp
+++ b/TAO/TAO_IDL/util/utl_scope.cpp
@@ -265,13 +265,11 @@ UTL_Scope::idl_keyword_clash (Identifier *e)
       if (idl_global->case_diff_error ())
         {
           idl_global->err ()->idl_keyword_error (tmp);
-        }
-      else
-        {
-          idl_global->err ()->idl_keyword_warning (tmp);
+
+          return -1;
         }
 
-      return -1;
+      idl_global->err ()->idl_keyword_warning (tmp);
     }
 
   return 0;

--- a/TAO/tests/IDL_Test/keyword_case_diff.idl
+++ b/TAO/tests/IDL_Test/keyword_case_diff.idl
@@ -1,0 +1,24 @@
+
+//=============================================================================
+/**
+ *  @file    keyword_case_diff.idl
+ *
+ *  This file contains examples of IDL code that has
+ *  caused problems in the past for the TAO IDL
+ *  compiler. This test is to make sure the problems
+ *  stay fixed.
+ */
+//=============================================================================
+
+
+module MyModule {
+  interface PortType { // This type differs from an IDL keyword only in case
+    exception MyException {
+      string myString;
+    };
+
+    void myMethod ()
+      raises (MyModule::PortType::MyException);
+  };
+};
+

--- a/TAO/tests/IDL_Test/run_test.pl
+++ b/TAO/tests/IDL_Test/run_test.pl
@@ -43,7 +43,49 @@ my $input_file3 = $server3->LocalFile ("invalid_scoping2.idl");
 
 # Compile the IDL
 $SV = $server3->CreateProcess ("$tao_idl", "$input_file3");
-$test3 = $SV->SpawnWaitKill ($server2->ProcessStartWaitInterval());
+$test3 = $SV->SpawnWaitKill ($server3->ProcessStartWaitInterval());
+
+my $server4 = PerlACE::TestTarget::create_target (4) || die "Create target 4 failed\n";
+my $input_file4 = $server4->LocalFile ("keyword_case_diff.idl");
+
+# Compile the IDL
+$SV = $server4->CreateProcess ("$tao_idl", "$input_file4");
+$test4 = $SV->SpawnWaitKill ($server4->ProcessStartWaitInterval());
+
+my $server5 = PerlACE::TestTarget::create_target (5) || die "Create target 5 failed\n";
+my $input_file5 = $server5->LocalFile ("keyword_case_diff.idl");
+my $result_filename5 = "keyword_case_diff.log";
+my $result_file5 = $server5->LocalFile ($result_filename5);
+
+open (STDERR, ">$result_file5") or die "can't redirect stderr: $!";
+
+# Compile the IDL
+$SV = $server5->CreateProcess ("$tao_idl", " -Cw $input_file5");
+$test5 = $SV->SpawnWaitKill ($server5->ProcessStartWaitInterval());
+
+open (STDERR, ">&STDOUT");
+
+sub analyze_results {
+    my $result_file = $_[0];
+
+    if (! -r $result_file) {
+        print STDERR "ERROR: cannot find $result_file\n";
+        return 1;
+    }
+
+    my $match = 0;
+    open (FILE, $result_file) or return -1;
+    while (<FILE>) {
+        $match = /Warning - spelling differs from IDL keyword only in case:/;
+        last if $match;
+    }
+    close FILE;
+
+    return $match ? 0 : -1;
+}
+
+$match5 = analyze_results($result_file5);
+$server5->DeleteFile($result_filename5);
 
 #Redirect the null device output back to the screen
 open (STDOUT, ">&OLDOUT");
@@ -54,6 +96,18 @@ if ($test2== 0) {
 }
 if ($test3== 0) {
     print STDERR "ERROR: tao_idl returned $test3 for $input_file3, should have failed!\n";
+    $status = 1;
+}
+if ($test4== 0) {
+    print STDERR "ERROR: tao_idl returned $test4 for $input_file4, should have failed!\n";
+    $status = 1;
+}
+if ($test5!= 0) {
+    print STDERR "ERROR: tao_idl -Cw returned $test5 for $input_file5, should have succeeded!\n";
+    $status = 1;
+}
+if ($match5!= 0) {
+    print STDERR "ERROR: tao_idl -Cw should have printed warning for $input_file5\n";
     $status = 1;
 }
 


### PR DESCRIPTION
tao_idl is not able to compile IDL files which have an identifier
that differs only in case from an IDL keyword, even if the '-Cw'
flag is used. For example:

```
$ cat > MyModule.idl << EOF
module MyModule {
	interface PortType {
		exception MyException {
			string myString;
		};

		void myMethod ()
			raises (MyModule::PortType::MyException);
	};
};
EOF
$ tao_idl -Cw MyModule.idl
Error - tao_idl: "MyModule.idl", line 2: Warning - spelling differs from IDL keyword only in case: "PortType"
Error - tao_idl: "MyModule.idl", line 2: Warning - spelling differs from IDL keyword only in case: "PortType"
Error - tao_idl: "MyModule.idl", line 8: Warning - spelling differs from IDL keyword only in case: "PortType"
Error - tao_idl: "MyModule.idl", line 8: error in lookup of symbol: MyModule::PortType::MyException
```

This change allows such IDL files to compile when '-Cw' is used;
only the warnings still appear.

Signed-off-by: David Ward <david.ward@ll.mit.edu>