### PR TITLE
Extend SL2 Security Manager

### DIFF
--- a/TAO/NEWS
+++ b/TAO/NEWS
@@ -1,6 +1,9 @@
 USER VISIBLE CHANGES BETWEEN TAO-2.3.2 and TAO-2.3.3
 ====================================================
 
+. Extended SL2 Security Manager to easily allow non-secure collocated
+  invocations but still disallow non-secure remote invocations
+
 USER VISIBLE CHANGES BETWEEN TAO-2.3.1 and TAO-2.3.2
 ====================================================
 

--- a/TAO/bin/tao_other_tests.lst
+++ b/TAO/bin/tao_other_tests.lst
@@ -207,7 +207,7 @@ TAO/orbsvcs/tests/Bug_3387_Regression/run_test.pl: !ST !NO_MESSAGING !MINIMUM !C
 #HANGS'TAO/orbsvcs/tests/ImplRepo/run_test.pl airplane_ir
 TAO/orbsvcs/tests/Security/Secure_Invocation/run_test.pl: SSL !STATIC !DISABLE_INTERCEPTORS !ACE_FOR_TAO !MINIMUM !CORBA_E_COMPACT !CORBA_E_MICRO
 TAO/orbsvcs/tests/Security/Bug_1107_Regression/run_test.pl: SSL !STATIC !DISABLE_INTERCEPTORS !ACE_FOR_TAO !MINIMUM !CORBA_E_COMPACT !CORBA_E_MICRO
-TAO/orbsvcs/tests/Security/Bug_2908_Regression/run_test.pl: SSL !STATIC !DISABLE_INTERCEPTORS !ACE_FOR_TAO !FIXED_BUGS_ONLY !MINIMUM !CORBA_E_COMPACT !CORBA_E_MICRO
+TAO/orbsvcs/tests/Security/Bug_2908_Regression/run_test.pl: SSL !STATIC !DISABLE_INTERCEPTORS !ACE_FOR_TAO !MINIMUM !CORBA_E_COMPACT !CORBA_E_MICRO
 TAO/orbsvcs/tests/Security/Big_Request/run_test.pl: SSL !STATIC !DISABLE_INTERCEPTORS !ACE_FOR_TAO !MINIMUM !CORBA_E_COMPACT !CORBA_E_MICRO
 TAO/orbsvcs/tests/Security/BiDirectional/run_test.pl: SSL !STATIC !DISABLE_INTERCEPTORS !ACE_FOR_TAO !MINIMUM !CORBA_E_COMPACT !CORBA_E_MICRO
 TAO/orbsvcs/tests/Security/Callback/run_test.pl: SSL !STATIC !DISABLE_INTERCEPTORS !ACE_FOR_TAO !MINIMUM !CORBA_E_COMPACT !CORBA_E_MICRO

--- a/TAO/orbsvcs/orbsvcs/SSLIOP/SSLIOP_Invocation_Interceptor.cpp
+++ b/TAO/orbsvcs/orbsvcs/SSLIOP/SSLIOP_Invocation_Interceptor.cpp
@@ -30,21 +30,17 @@ TAO::SSLIOP::Server_Invocation_Interceptor::Server_Invocation_Interceptor (
 
   if (!CORBA::is_nil (this->ssliop_current_.in ()))
     {
-      // For the remote instance we already do this
-      if (!this->collocated_)
-        {
-          TAO::SSLIOP::Current *tao_current =
-            dynamic_cast<TAO::SSLIOP::Current *> (this->ssliop_current_.in ());
+      TAO::SSLIOP::Current *tao_current =
+        dynamic_cast<TAO::SSLIOP::Current *> (this->ssliop_current_.in ());
 
-          if (tao_current != 0)
-            {
-              if (TAO_debug_level > 3)
-                ORBSVCS_DEBUG ((LM_DEBUG, "TAO (%P|%t) SSLIOP_Invocation_Interceptor::CTOR--setting up SSLIOP Current with slot %d\n", tss_slot));
-              tao_current->tss_slot (tss_slot);
-            }
-          else
-            throw CORBA::INTERNAL ();
+      if (tao_current != 0)
+        {
+          if (TAO_debug_level > 3)
+            ORBSVCS_DEBUG ((LM_DEBUG, "TAO (%P|%t) SSLIOP_Invocation_Interceptor::CTOR--setting up SSLIOP Current with slot %d\n", tss_slot));
+          tao_current->tss_slot (tss_slot);
         }
+      else
+        throw CORBA::INTERNAL ();
     }
 
   obj = info->resolve_initial_references ("SecurityLevel2:SecurityManager");

--- a/TAO/orbsvcs/orbsvcs/SSLIOP/SSLIOP_Invocation_Interceptor.cpp
+++ b/TAO/orbsvcs/orbsvcs/SSLIOP/SSLIOP_Invocation_Interceptor.cpp
@@ -149,12 +149,12 @@ TAO::SSLIOP::Server_Invocation_Interceptor::receive_request (
       CORBA::OctetSeq_var object_id = ri->object_id ();
       CORBA::String_var operation_name = ri->operation ();
 
-      CORBA::Boolean it_should_happen = false;
-      it_should_happen = ad->access_allowed_ex (orb_id.in (),
-                                                adapter_id.in (),
-                                                object_id.in (),
-                                                cred_list,
-                                                operation_name.in());
+      CORBA::Boolean const it_should_happen =
+        ad->access_allowed_ex (orb_id.in (),
+                               adapter_id.in (),
+                               object_id.in (),
+                               cred_list,
+                               operation_name.in());
       if (TAO_debug_level >= 3)
         {
           ORBSVCS_DEBUG ((LM_DEBUG,

--- a/TAO/orbsvcs/orbsvcs/SSLIOP/SSLIOP_Invocation_Interceptor.cpp
+++ b/TAO/orbsvcs/orbsvcs/SSLIOP/SSLIOP_Invocation_Interceptor.cpp
@@ -9,25 +9,20 @@
 #include "tao/PortableServer/POAC.h"
 #include "tao/debug.h"
 
-#if defined (SSLIOP_DEBUG_PEER_CERTIFICATE)
-#include <openssl/x509.h>   // @@ For debugging code below
-#endif /* SSLIOP_DEBUG_PEER_CERTIFICATE */
-
 TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
-TAO::SSLIOP::Server_Invocation_Interceptor::Server_Invocation_Interceptor
-(
+TAO::SSLIOP::Server_Invocation_Interceptor::Server_Invocation_Interceptor (
   PortableInterceptor::ORBInitInfo_ptr info,
   ::Security::QOP default_qop,
-  size_t tss_slot
-)
-: qop_ (default_qop)
+  size_t tss_slot,
+  bool collocated)
+  : qop_ (default_qop),
+    collocated_ (collocated)
 {
   /*
    * Cache references to the "Current" objects that we'll need during
    * during invocations.
    */
-
   CORBA::Object_var obj =
     info->resolve_initial_references ("SSLIOPCurrent");
 
@@ -35,45 +30,38 @@ TAO::SSLIOP::Server_Invocation_Interceptor::Server_Invocation_Interceptor
 
   if (!CORBA::is_nil (this->ssliop_current_.in ()))
     {
-      TAO::SSLIOP::Current *tao_current =
-        dynamic_cast<TAO::SSLIOP::Current *> (this->ssliop_current_.in ());
-
-      if (tao_current != 0)
+      // For the remote instance we already do this
+      if (!this->collocated_)
         {
-          if (TAO_debug_level > 3)
-            ORBSVCS_DEBUG ((LM_DEBUG, "TAO (%P|%t) SSLIOP_Invocation_Interceptor::CTOR--setting up SSLIOP Current with slot %d\n", tss_slot));
-          tao_current->tss_slot (tss_slot);
+          TAO::SSLIOP::Current *tao_current =
+            dynamic_cast<TAO::SSLIOP::Current *> (this->ssliop_current_.in ());
+
+          if (tao_current != 0)
+            {
+              if (TAO_debug_level > 3)
+                ORBSVCS_DEBUG ((LM_DEBUG, "TAO (%P|%t) SSLIOP_Invocation_Interceptor::CTOR--setting up SSLIOP Current with slot %d\n", tss_slot));
+              tao_current->tss_slot (tss_slot);
+            }
+          else
+            throw CORBA::INTERNAL ();
         }
-      else
-        throw CORBA::INTERNAL ();
     }
 
   obj = info->resolve_initial_references ("SecurityLevel2:SecurityManager");
   this->sec2manager_ = SecurityLevel2::SecurityManager::_narrow (obj.in ());
-
-  if (! CORBA::is_nil (this->sec2manager_.in ()))
-    {
-      // set the slot id?  things seem to work without doing this
-    }
-
-#if 0
-  // Don't need this now that we're not using access_allowed(), but
-  // I'm leaving the code here just in case it would become convenient
-  // for some other use.
-  obj = info->resolve_initial_references ("POACurrent");
-  this->poa_current_ = PortableServer::Current::_narrow (obj.in ());
-#endif
 }
 
-TAO::SSLIOP::Server_Invocation_Interceptor::~Server_Invocation_Interceptor (
-  void)
+TAO::SSLIOP::Server_Invocation_Interceptor::~Server_Invocation_Interceptor (void)
 {
 }
 
 char *
 TAO::SSLIOP::Server_Invocation_Interceptor::name ()
 {
-  return CORBA::string_dup ("TAO::SSLIOP::Server_Invocation_Interceptor");
+  if (this->collocated_)
+    return CORBA::string_dup ("TAO::SSLIOP::Server_Invocation_Interceptor::Collocated");
+  else
+    return CORBA::string_dup ("TAO::SSLIOP::Server_Invocation_Interceptor::Remote");
 }
 
 void
@@ -89,7 +77,7 @@ TAO::SSLIOP::Server_Invocation_Interceptor::receive_request_service_contexts (
 
 void
 TAO::SSLIOP::Server_Invocation_Interceptor::receive_request (
-    PortableInterceptor::ServerRequestInfo_ptr ri )
+    PortableInterceptor::ServerRequestInfo_ptr ri)
 {
   SecurityLevel2::AccessDecision_var ad_tmp =
     this->sec2manager_->access_decision ();
@@ -100,7 +88,7 @@ TAO::SSLIOP::Server_Invocation_Interceptor::receive_request (
     this->ssliop_current_->no_context ();
 
   if (TAO_debug_level >= 3)
-    ORBSVCS_DEBUG ((LM_DEBUG, "SSLIOP (%P|%t) Interceptor (context), ssl=%d\n", !(no_ssl)));
+    ORBSVCS_DEBUG ((LM_DEBUG, "SSLIOP (%P|%t) Interceptor (context), ssl=%d collocated=%d\n", !(no_ssl), this->collocated_));
 
   // if
   // (1) no SSL session state is available (which means that the
@@ -141,7 +129,6 @@ TAO::SSLIOP::Server_Invocation_Interceptor::receive_request (
       catch (...) {
       }
 #endif
-
       /* Gather the elements that uniquely identify the target object */
       CORBA::ORBid_var orb_id = ri->orb_id ();
       CORBA::OctetSeq_var adapter_id = ri->adapter_id ();
@@ -153,11 +140,13 @@ TAO::SSLIOP::Server_Invocation_Interceptor::receive_request (
                                adapter_id.in (),
                                object_id.in (),
                                cred_list,
-                               operation_name.in());
+                               operation_name.in(),
+                               this->collocated_);
+
       if (TAO_debug_level >= 3)
         {
           ORBSVCS_DEBUG ((LM_DEBUG,
-            "TAO (%P|%t) SL2::access_allowed_ex returned %s\n",
+            "TAO (%P|%t) SL2::access_allowed_ex returned %C\n",
             it_should_happen ? "true" : "false"));
         }
 

--- a/TAO/orbsvcs/orbsvcs/SSLIOP/SSLIOP_Invocation_Interceptor.cpp
+++ b/TAO/orbsvcs/orbsvcs/SSLIOP/SSLIOP_Invocation_Interceptor.cpp
@@ -87,7 +87,6 @@ TAO::SSLIOP::Server_Invocation_Interceptor::receive_request_service_contexts (
 {
 }
 
-
 void
 TAO::SSLIOP::Server_Invocation_Interceptor::receive_request (
     PortableInterceptor::ServerRequestInfo_ptr ri )

--- a/TAO/orbsvcs/orbsvcs/SSLIOP/SSLIOP_Invocation_Interceptor.h
+++ b/TAO/orbsvcs/orbsvcs/SSLIOP/SSLIOP_Invocation_Interceptor.h
@@ -48,7 +48,10 @@ namespace TAO
      *
      * This server request interceptor rejects insecure request
      * invocations if the effective target object policy requires
-     * secure invocations.
+     * secure invocations. Two instances are going to be used,
+     * one for collocated and one for remote invocations because
+     * within the interception point we don't know whether we
+     * are collocated or not
      */
     class Server_Invocation_Interceptor
       : public virtual PortableInterceptor::ServerRequestInterceptor,
@@ -62,10 +65,12 @@ namespace TAO
                     the interceptor can get access to initial references, etc.
         \param default_qop the default Quality of Protection
         \param tss_slot the TSS slot used by the various security features.
+        \param collocated Are we handling collocated calls in this instance or not
       */
       Server_Invocation_Interceptor (PortableInterceptor::ORBInitInfo_ptr info,
                                      ::Security::QOP default_qop,
-                                     size_t tss_slot);
+                                     size_t tss_slot,
+                                     bool collocated);
 
       /**
        * @name PortableInterceptor::ServerRequestInterceptor Methods
@@ -126,6 +131,9 @@ namespace TAO
 
       /// The default quality-of-protection settings in use.
       ::Security::QOP qop_;
+
+      /// Are we handling collocated calls
+      bool collocated_;
 
       /// SecurityLevel2 security manager reference
       SecurityLevel2::SecurityManager_var sec2manager_;

--- a/TAO/orbsvcs/orbsvcs/SSLIOP/SSLIOP_ORBInitializer.cpp
+++ b/TAO/orbsvcs/orbsvcs/SSLIOP/SSLIOP_ORBInitializer.cpp
@@ -63,6 +63,17 @@ void
 TAO::SSLIOP::ORBInitializer::post_init (
     PortableInterceptor::ORBInitInfo_ptr info)
 {
+  // TAO-Specific way to get to the ORB Core (and thus, the ORB).
+  TAO_ORBInitInfo_var tao_info =
+    TAO_ORBInitInfo::_narrow (info);
+
+  CORBA::ORB_var orb = CORBA::ORB::_duplicate(tao_info->orb_core()->orb());
+
+  if (CORBA::is_nil(orb.in()))
+    {
+      throw CORBA::INTERNAL ();
+    }
+
   // Note we do not store the SSLIOP::Current as a class member since
   // we need to avoid potential problems where the same
   // SSLIOP::Current object is shared between ORBs.  Each ORB should
@@ -73,29 +84,76 @@ TAO::SSLIOP::ORBInitializer::post_init (
   // object is registered for each ORB in this ORBInitializer's
   // pre_init() method.
 
-  // Create the SSLIOP secure invocation server request interceptor.
-  PortableInterceptor::ServerRequestInterceptor_ptr si =
+  // Create two interceptors, one for collocated and one for remote calls
+  size_t const slot = this->get_tss_slot_id (info);
+  // Create the SSLIOP secure remote invocation server request interceptor.
+  PortableInterceptor::ServerRequestInterceptor_ptr si_remote =
     PortableInterceptor::ServerRequestInterceptor::_nil ();
-  ACE_NEW_THROW_EX (si,
+  ACE_NEW_THROW_EX (si_remote,
                     TAO::SSLIOP::Server_Invocation_Interceptor(
                       info,
                       this->qop_,
-                      this->get_tss_slot_id (info)),
+                      slot,
+                      false), // Remote calls
                       CORBA::NO_MEMORY (CORBA::SystemException::_tao_minor_code (TAO::VMCID,
                                                                                  ENOMEM),
                                                                                  CORBA::COMPLETED_NO));
+  PortableInterceptor::ServerRequestInterceptor_var si_remote_interceptor = si_remote;
 
-  PortableInterceptor::ServerRequestInterceptor_var si_interceptor =
-    si;
+  // Create the SSLIOP secure collocated invocation server request interceptor.
+  PortableInterceptor::ServerRequestInterceptor_ptr si_collocated =
+    PortableInterceptor::ServerRequestInterceptor::_nil ();
+  ACE_NEW_THROW_EX (si_collocated,
+                    TAO::SSLIOP::Server_Invocation_Interceptor(
+                      info,
+                      this->qop_,
+                      slot,
+                      true), // Collocated calls
+                      CORBA::NO_MEMORY (CORBA::SystemException::_tao_minor_code (TAO::VMCID,
+                                                                                 ENOMEM),
+                                                                                 CORBA::COMPLETED_NO));
+  PortableInterceptor::ServerRequestInterceptor_var si_collocated_interceptor = si_collocated;
+
+  PortableInterceptor::ORBInitInfo_3_1_var info_3_1 =
+    PortableInterceptor::ORBInitInfo_3_1::_narrow(info);
+
+  if (CORBA::is_nil(info_3_1.in()))
+    {
+      throw CORBA::INTERNAL ();
+    }
+
+  CORBA::Any remote_proc_mode_as_any;
+  CORBA::Any collocated_proc_mode_as_any;
+  remote_proc_mode_as_any <<= PortableInterceptor::REMOTE_ONLY;
+  collocated_proc_mode_as_any <<= PortableInterceptor::LOCAL_ONLY;
+  CORBA::PolicyList policy_list_remote (1);
+  CORBA::PolicyList policy_list_collocated (1);
+  policy_list_remote.length (1);
+  policy_list_collocated.length (1);
+  policy_list_remote[0] =
+    orb->create_policy (PortableInterceptor::PROCESSING_MODE_POLICY_TYPE,
+                        remote_proc_mode_as_any);
+  policy_list_collocated[0] =
+    orb->create_policy (PortableInterceptor::PROCESSING_MODE_POLICY_TYPE,
+                        collocated_proc_mode_as_any);
 
   // Register the SSLIOP secure invocation server request interceptor
   // with the ORB.
-  info->add_server_request_interceptor (si_interceptor.in ());
+  info_3_1->add_server_request_interceptor_with_policy (si_remote_interceptor.in (), policy_list_remote);
+
+  // Register the SSLIOP secure invocation server request interceptor
+  // with the ORB.
+  info_3_1->add_server_request_interceptor_with_policy (si_collocated_interceptor.in (), policy_list_collocated);
+
+  policy_list_remote[0]->destroy ();
+  policy_list_collocated[0]->destroy ();
+  policy_list_remote[0] = CORBA::Policy::_nil ();
+  policy_list_collocated[0] = CORBA::Policy::_nil ();
 
   // Register the SSLIOP-specific vault with the
   // PrincipalAuthenticator.
   CORBA::Object_var obj =
-    info->resolve_initial_references ("SecurityLevel3:SecurityManager");
+    info_3_1->resolve_initial_references ("SecurityLevel3:SecurityManager");
 
   SecurityLevel3::SecurityManager_var manager =
     SecurityLevel3::SecurityManager::_narrow (obj.in ());

--- a/TAO/orbsvcs/orbsvcs/SSLIOP/SSLIOP_ORBInitializer.cpp
+++ b/TAO/orbsvcs/orbsvcs/SSLIOP/SSLIOP_ORBInitializer.cpp
@@ -92,35 +92,6 @@ TAO::SSLIOP::ORBInitializer::post_init (
   // with the ORB.
   info->add_server_request_interceptor (si_interceptor.in ());
 
-//   TAO_ORBInitInfo_var tao_info =
-//     TAO_ORBInitInfo::_narrow (info
-//);
-
-//   if (CORBA::is_nil (tao_info.in ()))
-//     ACE_THROW (CORBA::INV_OBJREF ());
-
-//   TAO_ORB_Core * orb_core = tao_info->orb_core ();
-
-//   // Create the SSLIOP IOR interceptor.
-//   PortableInterceptor::IORInterceptor_ptr ii =
-//     PortableInterceptor::IORInterceptor::_nil ();
-//   ACE_NEW_THROW_EX (ii,
-//                     TAO::SSLIOP::IORInterceptor (orb_core,
-//                                                  this->csiv2_target_supports_,
-//                                                  this->csiv2_target_requires_),
-//                     CORBA::NO_MEMORY (
-//                       CORBA::SystemException::_tao_minor_code (
-//                         TAO::VMCID,
-//                         ENOMEM),
-//                       CORBA::COMPLETED_NO));
-
-//   PortableInterceptor::IORInterceptor_var ior_interceptor =
-//     ii;
-
-//   // Register the SSLIOP IORInterceptor.
-//   info->add_ior_interceptor (ior_interceptor.in ()
-//);
-
   // Register the SSLIOP-specific vault with the
   // PrincipalAuthenticator.
   CORBA::Object_var obj =
@@ -135,7 +106,7 @@ TAO::SSLIOP::ORBInitializer::post_init (
   TAO::SL3::CredentialsCurator_var tao_curator =
     TAO::SL3::CredentialsCurator::_narrow (curator.in ());
 
-  TAO::SSLIOP::CredentialsAcquirerFactory * factory;
+  TAO::SSLIOP::CredentialsAcquirerFactory * factory = 0;
   ACE_NEW_THROW_EX (factory,
                     TAO::SSLIOP::CredentialsAcquirerFactory,
                     CORBA::NO_MEMORY ());

--- a/TAO/orbsvcs/orbsvcs/Security/SL2_SecurityManager.cpp
+++ b/TAO/orbsvcs/orbsvcs/Security/SL2_SecurityManager.cpp
@@ -161,7 +161,7 @@ TAO::Security::AccessDecision::access_allowed_i (OBJECT_KEY &key,
       access_decision = this->default_allowance_decision_;
       if (TAO_debug_level >= 3)
         ORBSVCS_DEBUG ((LM_DEBUG,
-                    "TAO (%P|%t) SL2_AccessDecision::access_decision(%x,%s)"
+                    "TAO (%P|%t) SL2_AccessDecision::access_decision(%x,%C)"
                     " NOT FOUND using default %d\n",
                     hash.operator()(key),
                     operation_name, access_decision));
@@ -169,7 +169,7 @@ TAO::Security::AccessDecision::access_allowed_i (OBJECT_KEY &key,
   else if (TAO_debug_level >= 3)
     {
       ORBSVCS_DEBUG ((LM_DEBUG,
-                  "TAO (%P|%t) SL2_AccessDecision::access_decision(%x,%s)"
+                  "TAO (%P|%t) SL2_AccessDecision::access_decision(%x,%C)"
                   " found with decision %d\n",
                   hash.operator()(key),
                   operation_name, access_decision));

--- a/TAO/orbsvcs/orbsvcs/Security/SL2_SecurityManager.cpp
+++ b/TAO/orbsvcs/orbsvcs/Security/SL2_SecurityManager.cpp
@@ -96,8 +96,8 @@ bool
 TAO::Security::AccessDecision::ReferenceKeyType::operator==
   (const ReferenceKeyType& other) const
 {
-  ::CORBA::ULong olen = this->oid_->length();
-  ::CORBA::ULong alen = this->adapter_id_->length();
+  ::CORBA::ULong const olen = this->oid_->length();
+  ::CORBA::ULong const alen = this->adapter_id_->length();
 
   if (olen == other.oid_->length() &&
       alen == other.adapter_id_->length())

--- a/TAO/orbsvcs/orbsvcs/Security/SL2_SecurityManager.cpp
+++ b/TAO/orbsvcs/orbsvcs/Security/SL2_SecurityManager.cpp
@@ -164,9 +164,9 @@ TAO::Security::AccessDecision::access_allowed_i (OBJECT_KEY &key,
       if (TAO_debug_level >= 3)
         ORBSVCS_DEBUG ((LM_DEBUG,
                     "TAO (%P|%t) SL2_AccessDecision::access_decision(%x,%C)"
-                    " NOT FOUND using default %d\n",
+                    " collocated %d NOT FOUND using default %d\n",
                     hash.operator()(key),
-                    operation_name, access_decision));
+                    operation_name, collocated, access_decision));
     }
   else if (TAO_debug_level >= 3)
     {

--- a/TAO/orbsvcs/orbsvcs/Security/SL2_SecurityManager.cpp
+++ b/TAO/orbsvcs/orbsvcs/Security/SL2_SecurityManager.cpp
@@ -159,8 +159,11 @@ TAO::Security::AccessDecision::access_allowed_i (OBJECT_KEY &key,
   CORBA::Boolean access_decision = false;
   if (this->access_map_.find (key, access_decision) == -1)
     {
-      // Couldn't find the IOR in the map, so we use the default dependent on collocation or not
-      access_decision = collocated ? this->default_collocated_decision_ : this->default_allowance_decision_;
+      // It is not in the map, so let us take the global default
+      access_decision = this->default_allowance_decision_;
+      // When collocated is enabled, this overrides the global value
+      if (this->default_collocated_decision_)
+        access_decision = true;
       if (TAO_debug_level >= 3)
         ORBSVCS_DEBUG ((LM_DEBUG,
                     "TAO (%P|%t) SL2_AccessDecision::access_decision(%x,%C)"

--- a/TAO/orbsvcs/orbsvcs/Security/SL2_SecurityManager.cpp
+++ b/TAO/orbsvcs/orbsvcs/Security/SL2_SecurityManager.cpp
@@ -121,7 +121,8 @@ TAO::Security::AccessDecision::ReferenceKeyType::operator const char* () const
 }
 
 TAO::Security::AccessDecision::AccessDecision ()
-  : default_allowance_decision_ (false)
+  : default_allowance_decision_ (false),
+    default_collocated_decision_ (false)
 {
 }
 
@@ -144,7 +145,8 @@ TAO::Security::AccessDecision::map_key_from_objref (CORBA::Object_ptr /*obj */)
 
 CORBA::Boolean
 TAO::Security::AccessDecision::access_allowed_i (OBJECT_KEY &key,
-                                                 const char *operation_name)
+                                                 const char *operation_name,
+                                                 CORBA::Boolean collocated)
 {
   // LOCK THE MAP!
   ACE_GUARD_RETURN (TAO_SYNCH_MUTEX, guard, this->map_lock_,
@@ -157,8 +159,8 @@ TAO::Security::AccessDecision::access_allowed_i (OBJECT_KEY &key,
   CORBA::Boolean access_decision = false;
   if (this->access_map_.find (key, access_decision) == -1)
     {
-      // Couldn't find the IOR in the map, so we use the default
-      access_decision = this->default_allowance_decision_;
+      // Couldn't find the IOR in the map, so we use the default dependent on collocation or not
+      access_decision = collocated ? this->default_collocated_decision_ : this->default_allowance_decision_;
       if (TAO_debug_level >= 3)
         ORBSVCS_DEBUG ((LM_DEBUG,
                     "TAO (%P|%t) SL2_AccessDecision::access_decision(%x,%C)"
@@ -186,14 +188,15 @@ TAO::Security::AccessDecision::access_allowed_ex (
           const ::CORBA::OctetSeq & adapter_id,
           const ::CORBA::OctetSeq & object_id,
           const ::SecurityLevel2::CredentialsList & /*cred_list */,
-          const char * operation_name)
+          const char * operation_name,
+          ::CORBA::Boolean collocated_invocation)
 {
   OBJECT_KEY key;
   key.orbid_ = orb_id;
   key.adapter_id_ = adapter_id;
   key.oid_ = object_id;
 
-  return this->access_allowed_i (key, operation_name);
+  return this->access_allowed_i (key, operation_name, collocated_invocation);
 }
 
 CORBA::Boolean
@@ -318,6 +321,18 @@ void
 TAO::Security::AccessDecision::default_decision (CORBA::Boolean d)
 {
   this->default_allowance_decision_ = d;
+}
+
+CORBA::Boolean
+TAO::Security::AccessDecision::default_collocated_decision (void)
+{
+  return this->default_collocated_decision_;
+}
+
+void
+TAO::Security::AccessDecision::default_collocated_decision (CORBA::Boolean d)
+{
+  this->default_collocated_decision_ = d;
 }
 
 TAO_END_VERSIONED_NAMESPACE_DECL

--- a/TAO/orbsvcs/orbsvcs/Security/SL2_SecurityManager.h
+++ b/TAO/orbsvcs/orbsvcs/Security/SL2_SecurityManager.h
@@ -54,7 +54,7 @@ namespace TAO
     {
     public:
       /*! Constructor */
-      AccessDecision (/* not yet known */);
+      AccessDecision (void);
       ~AccessDecision (void);
 
       virtual ::CORBA::Boolean access_allowed (

--- a/TAO/orbsvcs/orbsvcs/Security/SL2_SecurityManager.h
+++ b/TAO/orbsvcs/orbsvcs/Security/SL2_SecurityManager.h
@@ -68,10 +68,14 @@ namespace TAO
           const ::CORBA::OctetSeq & adapter_id,
           const ::CORBA::OctetSeq & object_id,
           const ::SecurityLevel2::CredentialsList & cred_list,
-          const char * operation_name);
+          const char * operation_name,
+          ::CORBA::Boolean collocated_invocation);
 
       virtual ::CORBA::Boolean default_decision (void);
       virtual void default_decision (::CORBA::Boolean d);
+
+      virtual ::CORBA::Boolean default_collocated_decision (void);
+      virtual void default_collocated_decision (::CORBA::Boolean d);
 
       virtual void add_object (const char * orbid,
                                const ::CORBA::OctetSeq & adapter_id,
@@ -89,6 +93,12 @@ namespace TAO
        */
       ::CORBA::Boolean default_allowance_decision_;
 
+      /*!
+       * This is the default value that's returned from access_allowed()
+       * when the access table doesn't contain an entry for the reference and
+       * we are handling a collocated call
+       */
+      ::CORBA::Boolean default_collocated_decision_;
       /*!
        * Map containing references and their designated insecure access.
        */
@@ -151,7 +161,8 @@ namespace TAO
       // This is the private implementation that is common to both
       // access_allowed and access_allowed_ex.
       ::CORBA::Boolean access_allowed_i (OBJECT_KEY& key,
-                                         const char *operation_name);
+                                         const char *operation_name,
+                                         CORBA::Boolean collocated = false);
 
     };
 

--- a/TAO/orbsvcs/orbsvcs/Security/SL3_SecurityManager.h
+++ b/TAO/orbsvcs/orbsvcs/Security/SL3_SecurityManager.h
@@ -28,7 +28,6 @@
 #pragma warning(disable:4250)
 #endif /* _MSC_VER */
 
-
 TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
 namespace TAO

--- a/TAO/orbsvcs/orbsvcs/SecurityLevel2.idl
+++ b/TAO/orbsvcs/orbsvcs/SecurityLevel2.idl
@@ -276,15 +276,21 @@ module TAO {
       // Parameter object_id should be PortableInterceptor::ObjectId, but
       // using that type would require including the PI_Forward.pidl file.
       // By using the real type, we can avoid that dependency.
-      boolean access_allowed_ex (in ::CORBA::ORBid orb_id,
+      boolean access_allowed_ex (
+         in ::CORBA::ORBid orb_id,
          in ::CORBA::OctetSeq adapter_id,
          in ::CORBA::OctetSeq object_id,
          in ::SecurityLevel2::CredentialsList cred_list,
-         in ::CORBA::Identifier operation_name);
+         in ::CORBA::Identifier operation_name,
+         in boolean collocation_invocation);
 
       /*! Default value returned when a reference is not in the list. */
       // Can't come up with a good name for this.
       attribute boolean default_decision;
+
+      /*! Default value returned when a reference is not in the list and we
+          are handling a collocated invocation. */
+      attribute boolean default_collocated_decision;
 
       /*! Establish whether a particular object can be accessed via insecure
           means. */

--- a/TAO/orbsvcs/orbsvcs/SecurityLevel2.idl
+++ b/TAO/orbsvcs/orbsvcs/SecurityLevel2.idl
@@ -285,11 +285,11 @@ module TAO {
          in boolean collocation_invocation);
 
       /*! Default value returned when a reference is not in the list. */
-      // Can't come up with a good name for this.
       attribute boolean default_decision;
 
       /*! Default value returned when a reference is not in the list and we
-          are handling a collocated invocation. */
+          are handling a collocated invocation. At the moment default_decision
+          is already true the value of this attribute doesn't matter anymore. */
       attribute boolean default_collocated_decision;
 
       /*! Establish whether a particular object can be accessed via insecure

--- a/TAO/orbsvcs/orbsvcs/SecurityLevel2.idl
+++ b/TAO/orbsvcs/orbsvcs/SecurityLevel2.idl
@@ -272,7 +272,7 @@ module TAO {
     local interface AccessDecision : SecurityLevel2::AccessDecision
     {
       /* TAO-specific access_allowed that works around deficiencies in
-   the SecurityLevel2::AccessDecision::access_allowed() operation. */
+         the SecurityLevel2::AccessDecision::access_allowed() operation. */
       // Parameter object_id should be PortableInterceptor::ObjectId, but
       // using that type would require including the PI_Forward.pidl file.
       // By using the real type, we can avoid that dependency.
@@ -287,7 +287,7 @@ module TAO {
       attribute boolean default_decision;
 
       /*! Establish whether a particular object can be accessed via insecure
-  means. */
+          means. */
       void add_object (in ::CORBA::ORBid orb_id,
                        in ::CORBA::OctetSeq adapter_id,
                        in ::CORBA::OctetSeq object_id,

--- a/TAO/orbsvcs/tests/Security/Bug_2908_Regression/Messenger.idl
+++ b/TAO/orbsvcs/tests/Security/Bug_2908_Regression/Messenger.idl
@@ -1,9 +1,15 @@
 interface Messenger
-    {
-        boolean send_message ( in    string user_name,
-                               in    string subject,
-                               inout string message );
+  {
+    boolean send_message (in string user_name,
+                          in string subject,
+                          inout string message );
 
-       boolean call_message( in    string user_name);
-    };
+    boolean call_message(in string user_name);
+
+    /// A method to shutdown the ORB
+    /**
+     * This method is used to simplify the test shutdown process
+     */
+    oneway void shutdown ();
+  };
 

--- a/TAO/orbsvcs/tests/Security/Bug_2908_Regression/MessengerClient.cpp
+++ b/TAO/orbsvcs/tests/Security/Bug_2908_Regression/MessengerClient.cpp
@@ -52,6 +52,8 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
 
     CORBA::String_var message = CORBA::string_dup("Hello!");
 
+    ACE_DEBUG((LM_DEBUG, "CLIENT: Start sending message\n"));
+
     // Send a message
     messenger->send_message("user", "TAO Test", message.inout());
 

--- a/TAO/orbsvcs/tests/Security/Bug_2908_Regression/MessengerClient.cpp
+++ b/TAO/orbsvcs/tests/Security/Bug_2908_Regression/MessengerClient.cpp
@@ -59,6 +59,8 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
 
     ACE_DEBUG((LM_DEBUG, "CLIENT: Message was sent\n"));
 
+    messenger->shutdown ();
+
     orb->destroy();
   }
   catch (const CORBA::Exception& ex)

--- a/TAO/orbsvcs/tests/Security/Bug_2908_Regression/MessengerServer.cpp
+++ b/TAO/orbsvcs/tests/Security/Bug_2908_Regression/MessengerServer.cpp
@@ -1,5 +1,6 @@
 #include "Messenger_i.h"
 #include "ace/Get_Opt.h"
+#include <orbsvcs/SecurityLevel2C.h>
 
 const ACE_TCHAR *ior_output_file = ACE_TEXT ("server.ior");
 
@@ -51,6 +52,20 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
     // Create an object
     Messenger_i messenger_servant (orb);
     Messenger_var messenger_factory = messenger_servant._this ();
+
+    // In order to allow collocated invocations we need to allow unsecured
+    // collocated invocations to the object else our security manager will
+    // block the collocated invocation unless you explicitly allow it
+    CORBA::Object_var sec_man =
+      orb->resolve_initial_references ("SecurityLevel2:SecurityManager");
+    SecurityLevel2::SecurityManager_var sec2manager =
+      SecurityLevel2::SecurityManager::_narrow (sec_man.in ());
+    SecurityLevel2::AccessDecision_var ad_tmp =
+      sec2manager->access_decision ();
+    TAO::SL2::AccessDecision_var ad =
+      TAO::SL2::AccessDecision::_narrow (ad_tmp.in ());
+    // Allow unsecured collocated invocations
+    ad->default_collocated_decision (true);
 
     CORBA::String_var ior =
       orb->object_to_string (messenger_factory.in ());

--- a/TAO/orbsvcs/tests/Security/Bug_2908_Regression/MessengerServer.cpp
+++ b/TAO/orbsvcs/tests/Security/Bug_2908_Regression/MessengerServer.cpp
@@ -70,6 +70,9 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
 
     // Accept requests
     orb->run();
+
+    poa->destroy (1, 1);
+
     orb->destroy();
   }
   catch (const CORBA::Exception&)

--- a/TAO/orbsvcs/tests/Security/Bug_2908_Regression/Messenger_i.cpp
+++ b/TAO/orbsvcs/tests/Security/Bug_2908_Regression/Messenger_i.cpp
@@ -14,12 +14,10 @@ Messenger_i::~Messenger_i (void)
 {
 }
 
-CORBA::Boolean Messenger_i::send_message (
-    const char *,
-    const char *,
-    char *&)
+CORBA::Boolean
+Messenger_i::send_message (const char *, const char *, char *&)
 {
-  ACE_DEBUG((LM_DEBUG, "\nInside send_message()...."));
+  ACE_DEBUG((LM_DEBUG, "Inside send_message()....\n"));
   const ACE_TCHAR *ior = ACE_TEXT("file://server.ior");
   CORBA::Object_var obj =
     orb_->string_to_object (ior);
@@ -49,9 +47,16 @@ CORBA::Boolean Messenger_i::send_message (
   return client_task.result_;
 }
 
-CORBA::Boolean Messenger_i::call_message (const char * user_name)
+CORBA::Boolean
+Messenger_i::call_message (const char * user_name)
 {
-    ACE_DEBUG((LM_DEBUG, "\nInside call_message()...."));
-    ACE_DEBUG((LM_DEBUG, "\nMessage from: %s", user_name));
+    ACE_DEBUG((LM_DEBUG, "Inside call_message()....\n"));
+    ACE_DEBUG((LM_DEBUG, "Message from: %s\n", user_name));
     return true;
+}
+
+void
+Messenger_i::shutdown (void)
+{
+  this->orb_->shutdown (0);
 }

--- a/TAO/orbsvcs/tests/Security/Bug_2908_Regression/Messenger_i.h
+++ b/TAO/orbsvcs/tests/Security/Bug_2908_Regression/Messenger_i.h
@@ -9,14 +9,14 @@
 #pragma once
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
-//Class Messenger_i
-class  Messenger_i : public virtual POA_Messenger
+// Class Messenger_i
+class Messenger_i : public virtual POA_Messenger
 {
 public:
-  //Constructor
+  // Constructor
   Messenger_i (CORBA::ORB_var orb);
 
-  //Destructor
+  // Destructor
   virtual ~Messenger_i (void);
 
   virtual CORBA::Boolean send_message ( const char * user_name,
@@ -24,6 +24,9 @@ public:
                                         char *& message);
 
   virtual CORBA::Boolean call_message (const char * user_name);
+
+  virtual void shutdown (void);
+
 private:
   CORBA::ORB_var orb_;
 };

--- a/TAO/tao/PI_Server/ServerRequestInfo.h
+++ b/TAO/tao/PI_Server/ServerRequestInfo.h
@@ -182,8 +182,7 @@ namespace TAO
     /// @c IOP::ServiceContextList.
     virtual void add_reply_service_context (
         const IOP::ServiceContext & service_context,
-        CORBA::Boolean replace
-        );
+        CORBA::Boolean replace);
 
   public:
 


### PR DESCRIPTION
Extend SL2 Security Manager with the ability to allow non-secure collocated request with one flag and still disable non-secure remote requests. Because within an interceptor we don't know whether we are invoked collocated or not we register two interceptors, one for the collocated and one for the remote case. 