### PR TITLE
Add ACE support for MacOS X 10.11 El Capitan

### DIFF
--- a/ACE/ace/config-macosx-elcapitan.h
+++ b/ACE/ace/config-macosx-elcapitan.h
@@ -1,0 +1,6 @@
+#ifndef ACE_CONFIG_MACOSX_ELCAPITAN_H
+#define ACE_CONFIG_MACOSX_ELCAPITAN_H
+
+#include "ace/config-macosx-yosemite.h"
+
+#endif // ACE_CONFIG_MACOSX_ELCAPITAN_H

--- a/ACE/include/makeinclude/platform_macosx_elcapitan.GNU
+++ b/ACE/include/makeinclude/platform_macosx_elcapitan.GNU
@@ -1,0 +1,3 @@
+
+include $(ACE_ROOT)/include/makeinclude/platform_macosx_yosemite.GNU
+


### PR DESCRIPTION
This simply points to the Yosemite configs, which seems to work fine.