### PR TITLE
Add static ACE_SSL_Context::close for deleting it.

### DIFF
--- a/ACE/ace/SSL/SSL_Context.cpp
+++ b/ACE/ace/SSL/SSL_Context.cpp
@@ -135,6 +135,12 @@ ACE_SSL_Context::instance (void)
 }
 
 void
+ACE_SSL_Context::close (void)
+{
+  ACE_Unmanaged_Singleton<ACE_SSL_Context, ACE_SYNCH_MUTEX>::close ();
+}
+
+void
 ACE_SSL_Context::ssl_library_init (void)
 {
   ACE_MT (ACE_GUARD (ACE_Recursive_Thread_Mutex,

--- a/ACE/ace/SSL/SSL_Context.h
+++ b/ACE/ace/SSL/SSL_Context.h
@@ -136,6 +136,9 @@ public:
   /// nothing else is available.
   static ACE_SSL_Context *instance (void);
 
+  /// Explicitly delete the Singleton context.
+  static void close (void);
+
   /**
    * Set the CTX mode.  The mode can be set only once, afterwards the
    * function has no effect and returns -1.

--- a/ACE/ace/SSL/SSL_Initializer.cpp
+++ b/ACE/ace/SSL/SSL_Initializer.cpp
@@ -25,7 +25,7 @@ int
 ACE_SSL_Initializer::fini (void)
 {
   // Explicitly close the ACE_SSL_Context singleton.
-  ACE_Unmanaged_Singleton<ACE_SSL_Context, ACE_SYNCH_MUTEX>::close();
+  ACE_SSL_Context::close ();
 
   return 0;
 }


### PR DESCRIPTION
Because ACE_SSL_Context is a unmanaged singleton, it would not
destruct without calling static close method explicitly.

ACE_SSL_Initializer can load and unload ACE_SSL_Context, but ACE_SSL_Context could not be closed without it.