### PR TITLE
Fix for the case when the compressed data is too large to fit

### DIFF
--- a/TAO/tao/GIOP_Message_Base.cpp
+++ b/TAO/tao/GIOP_Message_Base.cpp
@@ -677,20 +677,13 @@ TAO_GIOP_Message_Base::process_request_message (TAO_Transport *transport,
 #if defined (TAO_HAS_ZIOP) && TAO_HAS_ZIOP ==1
   if (qd->state ().compressed ())
     {
-      ACE_Data_Block *const orig_db = db;
       if (!this->decompress (&db, *qd, rd_pos, wr_pos))
         return -1;
-      if (orig_db != db)
+      if (qd->msg_block ()->data_block () != db)
         {
-          // Since the decompression has replaced our original datablock,
-          // if we were supposed to delete it, do so now.
-          if (ACE_BIT_DISABLED (flg, ACE_Message_Block::DONT_DELETE))
-            static_cast<void> (orig_db->release ());
-          else
-            // and make sure that the new datablock is always deleted by
-            // the upcomming input_cdr going out of scope as we have been
-            // given ownership of it.
-            ACE_CLR_BITS (flg, ACE_Message_Block::DONT_DELETE);
+          // qd still owns the original compressed buffer, db now has
+          // the uncompressed data which is on the heap
+          ACE_CLR_BITS (flg, ACE_Message_Block::DONT_DELETE);
         }
     }
 #endif
@@ -803,22 +796,15 @@ TAO_GIOP_Message_Base::process_reply_message (
   db->size (qd->msg_block ()->length ());
 
 #if defined (TAO_HAS_ZIOP) && TAO_HAS_ZIOP ==1
-   if (qd->state ().compressed ())
+  if (qd->state ().compressed ())
     {
-      ACE_Data_Block *const orig_db = db;
       if (!this->decompress (&db, *qd, rd_pos, wr_pos))
         return -1;
-      if (orig_db != db)
+      if (qd->msg_block ()->data_block () != db)
         {
-          // Since the decompression has replaced our original datablock,
-          // if we were supposed to delete it, do so now.
-          if (ACE_BIT_DISABLED (flg, ACE_Message_Block::DONT_DELETE))
-            static_cast<void> (orig_db->release ());
-          else
-            // and make sure that the new datablock is always deleted by
-            // the upcomming input_cdr going out of scope as we have been
-            // given ownership of it.
-            ACE_CLR_BITS (flg, ACE_Message_Block::DONT_DELETE);
+          // qd still owns the original compressed buffer, db now has
+          // the uncompressed data which is on the heap
+          ACE_CLR_BITS (flg, ACE_Message_Block::DONT_DELETE);
         }
     }
 #endif

--- a/TAO/tests/ZIOP/Hello.cpp
+++ b/TAO/tests/ZIOP/Hello.cpp
@@ -1,8 +1,7 @@
 #include "Hello.h"
 
 Hello::Hello (CORBA::ORB_ptr orb)
-  : length_ (40000u)
-  , orb_ (CORBA::ORB::_duplicate (orb))
+  : orb_ (CORBA::ORB::_duplicate (orb))
 {
 }
 
@@ -14,14 +13,14 @@ Hello::get_string (const char * mystring)
 }
 
 Test::Octet_Seq *
-Hello::get_big_reply ()
+Hello::get_big_reply (CORBA::ULong size)
 {
   Test::Octet_Seq_var reply_mesg =
-    new Test::Octet_Seq (this->length_);
+    new Test::Octet_Seq (size);
 
-  reply_mesg->length (this->length_);
+  reply_mesg->length (size);
 
-  for (unsigned int i = 0u; i < this->length_; ++i)
+  for (CORBA::ULong i = 0u; i < size; ++i)
     {
       reply_mesg[i]= static_cast<CORBA::Octet> (i & 0xff);
     }
@@ -34,12 +33,13 @@ Hello::big_request (const ::Test::Octet_Seq & octet_in)
   if (octet_in.length () > 0)
     {
       ACE_DEBUG ((LM_DEBUG,
-                  ACE_TEXT("Server side BLOB received\n")));
+                  ACE_TEXT("Server side BLOB received len = %d\n"),
+                  octet_in.length ()));
     }
   else
     {
       ACE_DEBUG ((LM_ERROR,
-                  ACE_TEXT("Error recieving BLOB on server\n")));
+                  ACE_TEXT("Error receiving BLOB on server\n")));
     }
 }
 

--- a/TAO/tests/ZIOP/Hello.h
+++ b/TAO/tests/ZIOP/Hello.h
@@ -13,7 +13,7 @@ public:
   /// Constructor
   Hello (CORBA::ORB_ptr orb);
 
-  virtual Test::Octet_Seq *get_big_reply ();
+  virtual Test::Octet_Seq *get_big_reply (CORBA::ULong size);
   virtual void big_request (const ::Test::Octet_Seq & octet_in);
 
   // = The skeleton methods
@@ -24,8 +24,6 @@ public:
 private:
   /// Use an ORB reference to convert strings to objects and shutdown
   /// the application.
-  CORBA::ULong length_;
-
   CORBA::ORB_var orb_;
 };
 

--- a/TAO/tests/ZIOP/Test.idl
+++ b/TAO/tests/ZIOP/Test.idl
@@ -12,7 +12,7 @@ module Test
     string get_string (in string mystring);
 
     /// Return binary info
-    Octet_Seq get_big_reply ();
+    Octet_Seq get_big_reply (in unsigned long size);
 
     ///recieve a large number of bytes
     void big_request (in Octet_Seq octet_in);

--- a/TAO/tests/ZIOP/server.cpp
+++ b/TAO/tests/ZIOP/server.cpp
@@ -54,10 +54,12 @@ register_factories (CORBA::ORB_ptr orb)
     ACE_ERROR_RETURN ((LM_ERROR,
                        " (%P|%t) Panic: nil compression manager\n"),
                       1);
-  //register Zlib compressor
   ::Compression::CompressorFactory_ptr compressor_factory;
+  ::Compression::CompressorFactory_var compr_fact;
+
+  //register Zlib compressor
   ACE_NEW_RETURN (compressor_factory, TAO::Zlib_CompressorFactory (), 1);
-  ::Compression::CompressorFactory_var compr_fact = compressor_factory;
+  compr_fact = compressor_factory;
   manager->register_factory(compr_fact.in ());
 
   // register bzip2 compressor


### PR DESCRIPTION
in the stack allocated buffer. Modify the test to accept a size value for testing the message size fix.