### PR TITLE
Remove version specific OpenSSL methods

### DIFF
--- a/ACE/ace/SSL/SSL_Context.cpp
+++ b/ACE/ace/SSL/SSL_Context.cpp
@@ -245,26 +245,6 @@ ACE_SSL_Context::set_mode (int mode)
 
   switch (mode)
     {
-#if !defined (OPENSSL_NO_SSL2)
-    case ACE_SSL_Context::SSLv2_client:
-      method = ::SSLv2_client_method ();
-      break;
-    case ACE_SSL_Context::SSLv2_server:
-      method = ::SSLv2_server_method ();
-      break;
-    case ACE_SSL_Context::SSLv2:
-      method = ::SSLv2_method ();
-      break;
-#endif /* OPENSSL_NO_SSL2 */
-    case ACE_SSL_Context::SSLv3_client:
-      method = ::SSLv3_client_method ();
-      break;
-    case ACE_SSL_Context::SSLv3_server:
-      method = ::SSLv3_server_method ();
-      break;
-    case ACE_SSL_Context::SSLv3:
-      method = ::SSLv3_method ();
-      break;
     case ACE_SSL_Context::SSLv23_client:
       method = ::SSLv23_client_method ();
       break;
@@ -274,39 +254,8 @@ ACE_SSL_Context::set_mode (int mode)
     case ACE_SSL_Context::SSLv23:
       method = ::SSLv23_method ();
       break;
-    case ACE_SSL_Context::TLSv1_client:
-      method = ::TLSv1_client_method ();
-      break;
-    case ACE_SSL_Context::TLSv1_server:
-      method = ::TLSv1_server_method ();
-      break;
-    case ACE_SSL_Context::TLSv1:
-      method = ::TLSv1_method ();
-      break;
-#if defined(TLS1_1_VERSION) && (TLS_MAX_VERSION >= TLS1_1_VERSION)
-    case ACE_SSL_Context::TLSv1_1_client:
-      method = ::TLSv1_1_client_method ();
-      break;
-    case ACE_SSL_Context::TLSv1_1_server:
-      method = ::TLSv1_1_server_method ();
-      break;
-    case ACE_SSL_Context::TLSv1_1:
-      method = ::TLSv1_1_method ();
-      break;
-#endif
-#if defined(TLS1_2_VERSION) && (TLS_MAX_VERSION >= TLS1_2_VERSION)
-    case ACE_SSL_Context::TLSv1_2_client:
-      method = ::TLSv1_2_client_method ();
-      break;
-    case ACE_SSL_Context::TLSv1_2_server:
-      method = ::TLSv1_2_server_method ();
-      break;
-    case ACE_SSL_Context::TLSv1_2:
-      method = ::TLSv1_2_method ();
-      break;
-#endif
     default:
-      method = ::SSLv3_method ();
+      method = ::SSLv23_method ();
       break;
     }
 
@@ -492,16 +441,7 @@ ACE_SSL_Context::load_trusted_ca (const char* ca_file,
 
   // For TLS/SSL servers scan all certificates in ca_file and ca_dir and
   // list them as acceptable CAs when requesting a client certificate.
-  if (mode_ == SSLv23
-      || mode_ == SSLv23_server
-      || mode_ == TLSv1
-      || mode_ == TLSv1_server
-#if !defined (OPENSSL_NO_SSL2)
-      || mode_ == SSLv2
-      || mode_ == SSLv2_server
-#endif /* !OPENSSL_NO_SSL2 */
-      || mode_ == SSLv3
-      || mode_ == SSLv3_server)
+  if (mode_ == SSLv23 || mode_ == SSLv23_server)
     {
       // Note: The STACK_OF(X509_NAME) pointer is a copy of the pointer in
       // the CTX; any changes to it by way of these function calls will

--- a/ACE/ace/SSL/SSL_Context.h
+++ b/ACE/ace/SSL/SSL_Context.h
@@ -104,26 +104,9 @@ public:
 
   enum {
     INVALID_METHOD = -1,
-#if !defined (OPENSSL_NO_SSL2)
-    SSLv2_client = 1,
-    SSLv2_server,
-    SSLv2,
-#endif /* !OPENSSL_NO_SSL2 */
-    SSLv3_client = 4,
-    SSLv3_server,
-    SSLv3,
     SSLv23_client,
     SSLv23_server,
     SSLv23,
-    TLSv1_client,
-    TLSv1_server,
-    TLSv1,
-    TLSv1_1_client,
-    TLSv1_1_server,
-    TLSv1_1,
-    TLSv1_2_client,
-    TLSv1_2_server,
-    TLSv1_2
   };
 
   /// Constructor

--- a/ACE/examples/C++NPv2/AC_Client_Logging_Daemon.cpp
+++ b/ACE/examples/C++NPv2/AC_Client_Logging_Daemon.cpp
@@ -318,7 +318,7 @@ int AC_CLD_Acceptor::handle_close (ACE_HANDLE,
 int AC_CLD_Connector::open (ACE_Reactor *r, int flags) {
   if (PARENT::open (r, flags) != 0) return -1;
   OpenSSL_add_ssl_algorithms ();
-  ssl_ctx_ = SSL_CTX_new (SSLv3_client_method ());
+  ssl_ctx_ = SSL_CTX_new (SSLv23_client_method ());
   if (ssl_ctx_ == 0) return -1;
 
   if (SSL_CTX_use_certificate_file (ssl_ctx_,

--- a/ACE/examples/C++NPv2/AIO_Client_Logging_Daemon.cpp
+++ b/ACE/examples/C++NPv2/AIO_Client_Logging_Daemon.cpp
@@ -235,7 +235,7 @@ int AIO_CLD_Connector::validate_connection
 
   if (ssl_ctx_ == 0) {
     OpenSSL_add_ssl_algorithms ();
-    ssl_ctx_ = SSL_CTX_new (SSLv3_client_method ());
+    ssl_ctx_ = SSL_CTX_new (SSLv23_client_method ());
     if (ssl_ctx_ == 0) return -1;
 
     if (SSL_CTX_use_certificate_file (ssl_ctx_,

--- a/ACE/examples/C++NPv2/TPC_Logging_Server.cpp
+++ b/ACE/examples/C++NPv2/TPC_Logging_Server.cpp
@@ -51,7 +51,7 @@ int TPC_Logging_Acceptor::open
                     use_select, reuse_addr) != 0)
     return -1;
   OpenSSL_add_ssl_algorithms ();
-  ssl_ctx_ = SSL_CTX_new (SSLv3_server_method ());
+  ssl_ctx_ = SSL_CTX_new (SSLv23_server_method ());
   if (ssl_ctx_ == 0) return -1;
 
   if (SSL_CTX_use_certificate_file (ssl_ctx_,

--- a/ACE/protocols/ace/INet/HTTPS_Context.cpp
+++ b/ACE/protocols/ace/INet/HTTPS_Context.cpp
@@ -16,7 +16,7 @@ namespace ACE
   namespace HTTPS
   {
 
-    int Context::ssl_mode_ =  ACE_SSL_Context::SSLv3;
+    int Context::ssl_mode_ =  ACE_SSL_Context::SSLv23;
     bool Context::ssl_strict_ = false;
     bool Context::ssl_once_ = true;
     int Context::ssl_depth_ = 0;

--- a/ACE/protocols/examples/INet/HTTP_Simple_exec.cpp
+++ b/ACE/protocols/examples/INet/HTTP_Simple_exec.cpp
@@ -16,7 +16,7 @@ u_short proxy_port = ACE::HTTP::URL::HTTP_PROXY_PORT;
 ACE_CString url;
 ACE_CString outfile;
 #if defined (ACE_HAS_SSL) && ACE_HAS_SSL == 1
-int ssl_mode = ACE_SSL_Context::SSLv3;
+int ssl_mode = ACE_SSL_Context::SSLv23;
 bool verify_peer = true;
 bool ignore_verify = false;
 ACE_CString certificate;
@@ -33,11 +33,6 @@ usage (void)
   std::cout << "\t-p <port>       \t\tproxy port to connect to\n";
   std::cout << "\t-o <filename>   \t\tfile to write output to\n";
 #if defined (ACE_HAS_SSL) && ACE_HAS_SSL == 1
-  std::cout << "\t-v <ssl version>\t\tSSL version to use: ";
-#if !defined (OPENSSL_NO_SSL2)
-  std::cout << "2, ";
-#endif /* OPENSSL_NO_SSL2 */
-  std::cout << "23, 3\n";
   std::cout << "\t-n              \t\tno peer certificate verification\n";
   std::cout << "\t-i              \t\tignore peer certificate verification failures\n";
   std::cout << "\t-c <filename>   \t\tcertificate file (PEM format)\n";
@@ -77,23 +72,6 @@ parse_args (int argc, ACE_TCHAR *argv [])
           break;
 
 #if defined (ACE_HAS_SSL) && ACE_HAS_SSL == 1
-        case 'v':
-          {
-            ACE_CString ver = ACE_TEXT_ALWAYS_CHAR (get_opt.opt_arg ());
-            if (ver == "23")
-              ssl_mode = ACE_SSL_Context::SSLv23;
-#if !defined (OPENSSL_NO_SSL2)
-            else if (ver == "2")
-              ssl_mode = ACE_SSL_Context::SSLv2;
-#endif /* ! OPENSSL_NO_SSL2*/
-            else if (ver != "3") // default mode
-              {
-                std::cerr << "ERROR: Invalid SSL mode [" << ver << "] specfied!" << std::endl;
-                return false;
-              }
-          }
-          break;
-
         case 'n':
           verify_peer = false;
           break;


### PR DESCRIPTION
The SSLv23_* methods are the only one that support multiple versions.

This is https://bugs.debian.org/804326