### PR TITLE
New ImR feature to force a remove of a running server.

### DIFF
--- a/TAO/NEWS
+++ b/TAO/NEWS
@@ -1,6 +1,10 @@
 USER VISIBLE CHANGES BETWEEN TAO-2.3.3 and TAO-2.3.4
 ====================================================
 
+. Added a "force remove" option to the Implementation repository that will remove
+  a server entry from the ImR Locator repository and kill any running instance with
+  a single command.
+
 USER VISIBLE CHANGES BETWEEN TAO-2.3.2 and TAO-2.3.3
 ====================================================
 

--- a/TAO/bin/imr_tests.lst
+++ b/TAO/bin/imr_tests.lst
@@ -29,6 +29,8 @@ TAO/orbsvcs/tests/ImplRepo/double_start/run_test.pl -kill: !ST !MINIMUM !CORBA_E
 TAO/orbsvcs/tests/ImplRepo/kill_server/run_test.pl: !MINIMUM !CORBA_E_COMPACT !CORBA_E_MICRO !WCHAR !LynxOS !ACE_FOR_TAO
 TAO/orbsvcs/tests/ImplRepo/kill_server/run_test.pl -rm2523: !MINIMUM !CORBA_E_COMPACT !CORBA_E_MICRO !WCHAR !LynxOS !ACE_FOR_TAO
 TAO/orbsvcs/tests/ImplRepo/kill_server/run_test.pl -rm2523 -start_delay 3: !MINIMUM !CORBA_E_COMPACT !CORBA_E_MICRO !WCHAR !LynxOS !ACE_FOR_TAO
+TAO/orbsvcs/tests/ImplRepo/kill_server/run_test.pl -rm2523 -force: !MINIMUM !CORBA_E_COMPACT !CORBA_E_MICRO !WCHAR !LynxOS !ACE_FOR_TAO
+TAO/orbsvcs/tests/ImplRepo/kill_server/run_test.pl -rm2523 -force -signal 15: !MINIMUM !CORBA_E_COMPACT !CORBA_E_MICRO !WCHAR !LynxOS !ACE_FOR_TAO
 TAO/orbsvcs/tests/ImplRepo/kill_slow_server/run_test.pl: !MINIMUM !CORBA_E_COMPACT !CORBA_E_MICRO !WCHAR !LynxOS !ACE_FOR_TAO
 TAO/orbsvcs/tests/ImplRepo/oneway/run_test.pl: !MINIMUM !CORBA_E_COMPACT !CORBA_E_MICRO !WCHAR !LynxOS !ACE_FOR_TAO
 TAO/orbsvcs/tests/ImplRepo/locked/run_test.pl: !MINIMUM !CORBA_E_COMPACT !CORBA_E_MICRO !WCHAR !LynxOS !ACE_FOR_TAO !OSX

--- a/TAO/bin/tao_other_tests.lst
+++ b/TAO/bin/tao_other_tests.lst
@@ -134,6 +134,8 @@ TAO/orbsvcs/tests/ImplRepo/double_start/run_test.pl -kill: !ST !MINIMUM !CORBA_E
 TAO/orbsvcs/tests/ImplRepo/kill_server/run_test.pl: !MINIMUM !CORBA_E_COMPACT !CORBA_E_MICRO !WCHAR !LynxOS !ACE_FOR_TAO
 TAO/orbsvcs/tests/ImplRepo/kill_server/run_test.pl -rm2523: !MINIMUM !CORBA_E_COMPACT !CORBA_E_MICRO !WCHAR !LynxOS !ACE_FOR_TAO
 TAO/orbsvcs/tests/ImplRepo/kill_server/run_test.pl -rm2523 -start_delay 3: !MINIMUM !CORBA_E_COMPACT !CORBA_E_MICRO !WCHAR !LynxOS !ACE_FOR_TAO
+TAO/orbsvcs/tests/ImplRepo/kill_server/run_test.pl -rm2523 -force: !MINIMUM !CORBA_E_COMPACT !CORBA_E_MICRO !WCHAR !LynxOS !ACE_FOR_TAO
+TAO/orbsvcs/tests/ImplRepo/kill_server/run_test.pl -rm2523 -force -signal 15: !MINIMUM !CORBA_E_COMPACT !CORBA_E_MICRO !WCHAR !LynxOS !ACE_FOR_TAO
 TAO/orbsvcs/tests/ImplRepo/kill_slow_server/run_test.pl: !MINIMUM !CORBA_E_COMPACT !CORBA_E_MICRO !WCHAR !LynxOS !ACE_FOR_TAO
 TAO/orbsvcs/tests/ImplRepo/oneway/run_test.pl: !MINIMUM !CORBA_E_COMPACT !CORBA_E_MICRO !WCHAR !LynxOS !ACE_FOR_TAO
 TAO/orbsvcs/tests/ImplRepo/locked/run_test.pl: !MINIMUM !CORBA_E_COMPACT !CORBA_E_MICRO !WCHAR !LynxOS !ACE_FOR_TAO

--- a/TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.h
+++ b/TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.h
@@ -64,13 +64,14 @@ class Locator_Export AsyncAccessManager
 
   void add_interest (ImR_ResponseHandler *rh, bool manual);
   ImplementationRepository::AAM_Status status (void) const;
+  bool force_remove_rh (ImR_ResponseHandler *rh);
 
   void activator_replied (bool success, int pid);
   void server_is_running (const char *partial_ior,
                           ImplementationRepository::ServerObject_ptr ref);
   void server_is_shutting_down (void);
   void shutdown_initiated (void);
-  bool notify_child_death (int pid = 0);
+  bool notify_child_death (int pid);
   void ping_replied (LiveStatus server);
 
   AsyncAccessManager *_add_ref (void);
@@ -88,6 +89,7 @@ class Locator_Export AsyncAccessManager
   UpdateableServerInfo info_;
   bool manual_start_;
   int retries_;
+  ImR_ResponseHandler *remove_on_death_rh_;
   ImR_Locator_i &locator_;
   PortableServer::POA_var poa_;
   ACE_Vector<ImR_ResponseHandler *> rh_list_;

--- a/TAO/orbsvcs/ImplRepo_Service/ImR_Locator_i.h
+++ b/TAO/orbsvcs/ImplRepo_Service/ImR_Locator_i.h
@@ -117,6 +117,11 @@ public:
     (ImplementationRepository::AMH_AdministrationResponseHandler_ptr _tao_rh,
      const char * name);
 
+  virtual void force_remove_server
+    (ImplementationRepository::AMH_AdministrationExtResponseHandler_ptr _tao_rh,
+     const char * name,
+     CORBA::Short signum);
+
   virtual void find
     (ImplementationRepository::AMH_AdministrationResponseHandler_ptr _tao_rh,
      const char * name);
@@ -163,6 +168,7 @@ public:
   PortableServer::POA_ptr root_poa (void);
   Activator_Info_Ptr get_activator (const ACE_CString& name);
 
+  void remove_server_i (const Server_Info_Ptr &si);
   void destroy_poa (const ACE_CString &poa_name);
   void remove_aam (AsyncAccessManager_ptr &aam);
   void remove_aam (const char *name);
@@ -200,6 +206,14 @@ private:
   void child_death_i (const char* name, int pid);
 
   void remove_aam_i (const char *name, bool active);
+
+  bool kill_server_i (const Server_Info_Ptr &si,
+                      CORBA::Short signum,
+                      CORBA::Exception *&ex);
+
+  bool shutdown_server_i (const Server_Info_Ptr &si,
+                          CORBA::Exception *&ex,
+                          bool force);
 
 private:
 
@@ -301,6 +315,7 @@ public:
     {
       LOC_ACTIVATE_SERVER,
       LOC_ADD_OR_UPDATE_SERVER,
+      LOC_FORCE_REMOVE_SERVER,
       LOC_REMOVE_SERVER,
       LOC_SHUTDOWN_SERVER,
       LOC_SERVER_IS_RUNNING,
@@ -309,14 +324,20 @@ public:
 
   ImR_Loc_ResponseHandler (Loc_Operation_Id opid,
                            ImplementationRepository::AMH_AdministrationResponseHandler_ptr rh);
+  ImR_Loc_ResponseHandler (Loc_Operation_Id opid,
+                           ImplementationRepository::AMH_AdministrationExtResponseHandler_ptr rh);
   virtual ~ImR_Loc_ResponseHandler (void);
 
   virtual void send_ior (const char *pior);
   virtual void send_exception (CORBA::Exception *ex);
 
 private:
+  void send_ior_ext (const char *pior);
+  void send_exception_ext (CORBA::Exception *ex);
+
   Loc_Operation_Id op_id_;
   ImplementationRepository::AMH_AdministrationResponseHandler_var resp_;
+  ImplementationRepository::AMH_AdministrationExtResponseHandler_var ext_;
 
 };
 

--- a/TAO/orbsvcs/ImplRepo_Service/tao_imr_i.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/tao_imr_i.cpp
@@ -612,7 +612,7 @@ TAO_IMR_Op_Remove::print_usage (void)
 {
   ORBSVCS_ERROR ((LM_ERROR, "Removes a server entry\n"
     "\n"
-    "Usage: tao_imr [options] remove [-f [-s <signum>]] <name>\n"
+    "Usage: tao_imr [options] remove <name> [-f [-s <signum>]]\n"
     "  where [options] are ORB options\n"
     "  -f forces shutdown or kill of a running server"
     "  -s specifies a signal for killing the server, if it is 0, a shutdown will be used"
@@ -631,10 +631,11 @@ TAO_IMR_Op_Remove::parse (int argc, ACE_TCHAR **argv)
     }
   this->force_ = false;
   this->signum_ = 0;
-  int server_arg = 1;
+
   // Skip both the program name and the "remove" command
   ACE_Get_Opt get_opts (argc, argv, ACE_TEXT("hfs:"));
 
+  this->server_name_ = ACE_TEXT_ALWAYS_CHAR(argv[1]);
   int c;
 
   while ((c = get_opts ()) != -1)
@@ -646,11 +647,9 @@ TAO_IMR_Op_Remove::parse (int argc, ACE_TCHAR **argv)
         return -1;
       case 'f':
         this->force_ = true;
-        ++server_arg;
         break;
       case 's':
         this->signum_ = ACE_OS::strtol (get_opts.opt_arg (), 0, 10);
-        server_arg += 2;
         break;
       default:
         ORBSVCS_ERROR((LM_ERROR, "ERROR : Unknown option '%c'\n", (char) c));
@@ -659,7 +658,6 @@ TAO_IMR_Op_Remove::parse (int argc, ACE_TCHAR **argv)
       }
     }
 
-  this->server_name_ = ACE_TEXT_ALWAYS_CHAR(argv[server_arg]);
   return 0;
 }
 

--- a/TAO/orbsvcs/ImplRepo_Service/tao_imr_i.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/tao_imr_i.cpp
@@ -612,8 +612,10 @@ TAO_IMR_Op_Remove::print_usage (void)
 {
   ORBSVCS_ERROR ((LM_ERROR, "Removes a server entry\n"
     "\n"
-    "Usage: tao_imr [options] remove <name>\n"
+    "Usage: tao_imr [options] remove [-f [-s <signum>]] <name>\n"
     "  where [options] are ORB options\n"
+    "  -f forces shutdown or kill of a running server"
+    "  -s specifies a signal for killing the server, if it is 0, a shutdown will be used"
     "  where <name> is the POA name used by the server object\n"
     "  -h Displays this\n"));
 }
@@ -627,11 +629,12 @@ TAO_IMR_Op_Remove::parse (int argc, ACE_TCHAR **argv)
       this->print_usage ();
       return -1;
     }
-
+  this->force_ = false;
+  this->signum_ = 0;
+  int server_arg = 1;
   // Skip both the program name and the "remove" command
-  ACE_Get_Opt get_opts (argc, argv, ACE_TEXT("h"));
+  ACE_Get_Opt get_opts (argc, argv, ACE_TEXT("hfs:"));
 
-  this->server_name_ = ACE_TEXT_ALWAYS_CHAR(argv[1]);
   int c;
 
   while ((c = get_opts ()) != -1)
@@ -641,12 +644,22 @@ TAO_IMR_Op_Remove::parse (int argc, ACE_TCHAR **argv)
       case 'h':
         this->print_usage ();
         return -1;
+      case 'f':
+        this->force_ = true;
+        ++server_arg;
+        break;
+      case 's':
+        this->signum_ = ACE_OS::strtol (get_opts.opt_arg (), 0, 10);
+        server_arg += 2;
+        break;
       default:
         ORBSVCS_ERROR((LM_ERROR, "ERROR : Unknown option '%c'\n", (char) c));
         this->print_usage ();
         return -1;
       }
     }
+
+  this->server_name_ = ACE_TEXT_ALWAYS_CHAR(argv[server_arg]);
   return 0;
 }
 
@@ -1217,8 +1230,18 @@ TAO_IMR_Op_Remove::run (void)
 
   try
     {
-      this->imr_->remove_server (this->server_name_.c_str ());
-
+      if (this->force_)
+        {
+          ImplementationRepository::AdministrationExt_var ext =
+            ImplementationRepository::AdministrationExt::_narrow (imr_);
+          ACE_ASSERT (! CORBA::is_nil(ext));
+          ext->force_remove_server (this->server_name_.c_str (),
+                                    this->signum_);
+        }
+      else
+        {
+          this->imr_->remove_server (this->server_name_.c_str ());
+        }
       ORBSVCS_DEBUG ((LM_DEBUG, "Successfully removed server <%C>\n",
         this->server_name_.c_str ()));
     }
@@ -1227,6 +1250,12 @@ TAO_IMR_Op_Remove::run (void)
       ORBSVCS_ERROR ((LM_ERROR, "Could not find server <%C>.\n",
         this->server_name_.c_str ()));
       return TAO_IMR_Op::NOT_FOUND;
+    }
+  catch (const ImplementationRepository::CannotComplete& cc)
+    {
+      ORBSVCS_ERROR ((LM_ERROR, "Could not complete forced removal of server <%C>. reason: %C\n",
+                      this->server_name_.c_str (), cc.reason.in() ));
+      return TAO_IMR_Op::CANNOT_COMPLETE;
     }
   catch (const CORBA::NO_PERMISSION& np)
     {

--- a/TAO/orbsvcs/ImplRepo_Service/tao_imr_i.h
+++ b/TAO/orbsvcs/ImplRepo_Service/tao_imr_i.h
@@ -287,6 +287,8 @@ protected:
   void print_usage (void);
 
   ACE_CString server_name_;
+  bool force_;
+  int signum_;
 };
 
 

--- a/TAO/orbsvcs/tests/ImplRepo/kill_server/run_test.pl
+++ b/TAO/orbsvcs/tests/ImplRepo/kill_server/run_test.pl
@@ -18,7 +18,7 @@ my $signalnum = 9;
 my $rm2523 = 0;
 my $act_delay = 800; #msec
 my $start_delay = 0; #sec
-my $rm_cmd = "remove";
+my $rm_opts = "";
 my $force = 0;
 
 if ($#ARGV >= 0) {
@@ -47,7 +47,7 @@ if ($#ARGV >= 0) {
             $servers_count = 3;
         }
         elsif ($ARGV[$i] eq "-force") {
-            $rm_cmd = "remove -f";
+            $rm_opts = "-f";
             $force = 1;
         }
         elsif ($ARGV[$i] eq "-start_delay") {
@@ -59,7 +59,7 @@ if ($#ARGV >= 0) {
 	    exit 1;
 	}
     }
-    $rm_cmd .= " -s $signalnum" if ($force == 1 && $sn_set == 1);
+    $rm_opts .= " -s $signalnum" if ($force == 1 && $sn_set == 1);
 }
 
 #$ENV{ACE_TEST_VERBOSE} = "1";
@@ -261,7 +261,7 @@ sub update_normal()
     $TI->Arguments ("-ORBInitRef ImplRepoService=file://$ti_imriorfile ".
                     "add $objprefix" . '_' . $i . "_a -c \"".
                     $srv_server_cmd[$i].
-                    " -ORBUseIMR 1 -n $i -ORBDebugLevel 10 -ORBLogFile svr.log ".
+                    " -ORBUseIMR 1 -n $i ".
                     "-orbendpoint iiop://localhost: " .
                     "-ORBInitRef ImplRepoService=file://$srv_imriorfile\"");
 
@@ -298,10 +298,10 @@ sub remove_entry(@)
     my $obj = shift;
     my $i = 1;
     $TI->Arguments ("-ORBInitRef ImplRepoService=file://$ti_imriorfile ".
-                    "$rm_cmd $objprefix" . '_' . $i . "_$obj");
+                    "remove $objprefix" . '_' . $i . "_$obj $rm_opts");
     $TI_status = $TI->SpawnWaitKill ($ti->ProcessStartWaitInterval());
     if ($TI_status != 0) {
-        print STDERR "tao_imr $rm_cmd returned $TI_status\n";
+        print STDERR "tao_imr remove $rm_opts returned $TI_status\n";
     }
 }
 

--- a/TAO/tao/ImR_Client/ImplRepo.idl
+++ b/TAO/tao/ImR_Client/ImplRepo.idl
@@ -206,6 +206,11 @@ module ImplementationRepository
     /// Have the approprate activator send a signal to the named server process
     void kill_server (in string server, in short signum)
       raises(NotFound, CannotComplete);
+
+    /// Combine the action of shutting down a running server instance if any via
+    /// a shutdown command if signum is 0, or via kill if signum is nonzero
+    void force_remove_server (in string server, in short signum)
+      raises(NotFound, CannotComplete);
   };
 };
 


### PR DESCRIPTION
This combines the steps of disabling restarts, shutting down or killing, then removing the registry entry into a single tao_imr invocation.