### PR TITLE
reword the news item about OpenSSL compatibility

### DIFF
--- a/ACE/NEWS
+++ b/ACE/NEWS
@@ -1,9 +1,12 @@
 USER VISIBLE CHANGES BETWEEN ACE-6.3.3 and ACE-6.3.4
 ====================================================
 
-. Removed support for SSLv2/SSLv3/TLSv1/TLS1.v2 because
-  they have been removed from OpenSSL because they are not
-  secure. SSL v2.3 is the only currently used
+. ACE_SSL_Context::set_mode() can no longer be used to select a specific
+  SSL/TLS protocol version, use ACE_SSL_Context::filter_versions() for that.
+  This follows general advice by the OpenSSL project to go through
+  SSL_CTX_set_options() to limit the list of protocols available. The purpose
+  of ACE_SSL_Context::set_mode() is now limited to explicitly restricting
+  behaviour to client or server (defaults to both).
 
 USER VISIBLE CHANGES BETWEEN ACE-6.3.2 and ACE-6.3.3
 ====================================================


### PR DESCRIPTION
@jwillemsen, please pull the fix for the news item according to our conversation on acb5b1f1f00653bcdf840afa6dc042a0b880a454.

Please keep in mind that `ACE_SSL_Context::filter_versions()` has issues that
should be addressed (I don't intend to spend time on ACE, sorry):

* documentation of `filter_versions()` says nothing - you either have to try or to read the ACE source code
* the interface of `filter_versions()` - passing a string with comma-delimited constants - is fragile
* `filter_versions()` requires constant maintenance - each time a new protocol is added
* `filter_versions()` is not (necessarily) forward-compatible because it disables any but the given protocols (also see kroeckx's comment on #156 about a new OpenSSL API for that)