### PR TITLE
some more (bundled) minor changes

### DIFF
--- a/ACE/ace/Abstract_Timer_Queue.h
+++ b/ACE/ace/Abstract_Timer_Queue.h
@@ -33,7 +33,7 @@ template<typename TYPE> class ACE_Timer_Node_T;
  * In short, the Reactor (and potentially other classes) want to refer
  * to timer queues regardless of the implementation internals.
  */
-template<typename TYPE>
+template <typename TYPE>
 class ACE_Abstract_Timer_Queue
 {
 public:
@@ -43,7 +43,7 @@ public:
   /// True if queue is empty, else false.
   virtual bool is_empty (void) const = 0;
 
-  /// Returns the time of the earlier node in the Timer_Queue.  Must
+  /// Returns the earliest due time in the Timer_Queue.  Must
   /// be called on a non-empty queue.
   virtual const ACE_Time_Value &earliest_time (void) const = 0;
 
@@ -62,7 +62,7 @@ public:
    * wrong timer.  Returns -1 on failure (which is guaranteed never to
    * be a valid <timer_id>).
    */
-  virtual long schedule (const TYPE &type,
+  virtual long schedule (TYPE *handler,
                          const void *act,
                          const ACE_Time_Value &future_time,
                          const ACE_Time_Value &interval = ACE_Time_Value::zero) = 0;
@@ -122,7 +122,7 @@ public:
    * only if an event will be dispatched, are encapsulated in the
    * ACE_Command_Base object.
    */
-  virtual int expire_single(ACE_Command_Base & pre_dispatch_command) = 0;
+  virtual int expire_single (ACE_Command_Base &pre_dispatch_command) = 0;
 
   /**
    * Resets the interval of the timer represented by @a timer_id to
@@ -140,8 +140,8 @@ public:
    * which typically invokes the <handle_close> hook.  Returns number
    * of timers cancelled.
    */
-  virtual int cancel (const TYPE &type,
-                      int dont_call_handle_close = 1) = 0;
+  virtual int cancel (TYPE *handler,
+                      int dont_call = 1) = 0;
 
   /**
    * Cancel the single timer that matches the @a timer_id value (which
@@ -171,7 +171,9 @@ public:
 
   /**
    * Allows applications to control how the timer queue gets the time
-   * of day.
+   * of day. Note: this will only have any effect when the TIME_POLICY
+   * is ACE_FPointer_Time_Policy. Other (standard ACE) time policies will
+   * ignore this.
    * @deprecated Use TIME_POLICY support instead. See Timer_Queue_T.h
    */
   virtual void gettimeofday (ACE_Time_Value (*gettimeofday)(void)) = 0;
@@ -194,17 +196,11 @@ public:
   virtual ACE_Time_Value *calculate_timeout (ACE_Time_Value *max,
                                              ACE_Time_Value *the_timeout) = 0;
 
-  /**
-   * Return the current time, using the right time policy and any
-   * timer skew defined in derived classes.
-   */
-  virtual ACE_Time_Value current_time() = 0;
-
   /// Type of Iterator.
-  typedef ACE_Timer_Queue_Iterator_T<TYPE> ITERATOR;
+  typedef ACE_Timer_Queue_Iterator_T<TYPE> ITERATOR_T;
 
   /// Returns a pointer to this ACE_Timer_Queue's iterator.
-  virtual ITERATOR & iter (void) = 0;
+  virtual ITERATOR_T &iter (void) = 0;
 
   /// Removes the earliest node from the queue and returns it
   virtual ACE_Timer_Node_T<TYPE> *remove_first (void) = 0;

--- a/ACE/ace/Asynch_IO.cpp
+++ b/ACE/ace/Asynch_IO.cpp
@@ -3,12 +3,14 @@
 #if defined (ACE_HAS_WIN32_OVERLAPPED_IO) || defined (ACE_HAS_AIO_CALLS)
 // This only works on platforms with Asynchronous IO
 
-#include "ace/Proactor.h"
-#include "ace/Message_Block.h"
-#include "ace/INET_Addr.h"
 #include "ace/Asynch_IO_Impl.h"
-#include "ace/os_include/os_errno.h"
+#include "ace/INET_Addr.h"
+#include "ace/Message_Block.h"
+#include "ace/Synch.h"
+#include "ace/Proactor.h"
 #include "ace/Truncate.h"
+
+#include "ace/os_include/os_errno.h"
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 

--- a/ACE/ace/Asynch_IO.h
+++ b/ACE/ace/Asynch_IO.h
@@ -33,17 +33,12 @@
 
 #if defined (ACE_HAS_WIN32_OVERLAPPED_IO) || defined (ACE_HAS_AIO_CALLS)
 
-#include "ace/Synch_Traits.h"
-#if defined (ACE_HAS_THREADS)
-#  include "ace/Thread_Mutex.h"
-#else
-#  include "ace/Null_Mutex.h"
-#endif /* ACE_HAS_THREADS */
-#include "ace/Refcounted_Auto_Ptr.h"
-
 #include "ace/os_include/os_signal.h"
 #include "ace/os_include/sys/os_socket.h"
 #include "ace/os_include/sys/os_types.h"
+
+#include "ace/Refcounted_Auto_Ptr.h"
+#include "ace/Synch_Traits.h"
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 

--- a/ACE/ace/Asynch_Pseudo_Task.cpp
+++ b/ACE/ace/Asynch_Pseudo_Task.cpp
@@ -1,3 +1,4 @@
+#include "ace/Synch.h"
 #include "ace/Asynch_Pseudo_Task.h"
 
 #include "ace/OS_NS_errno.h"

--- a/ACE/ace/Condition_Recursive_Thread_Mutex.cpp
+++ b/ACE/ace/Condition_Recursive_Thread_Mutex.cpp
@@ -108,18 +108,6 @@ ACE_Condition<ACE_Recursive_Thread_Mutex>::wait (ACE_Recursive_Thread_Mutex &mut
   return result;
 }
 
-int
-ACE_Condition<ACE_Recursive_Thread_Mutex>::signal (void)
-{
-  return ACE_OS::cond_signal (&this->cond_);
-}
-
-int
-ACE_Condition<ACE_Recursive_Thread_Mutex>::broadcast (void)
-{
-  return ACE_OS::cond_broadcast (&this->cond_);
-}
-
 ACE_END_VERSIONED_NAMESPACE_DECL
 
 #endif /* ACE_HAS_THREADS */

--- a/ACE/ace/Condition_Recursive_Thread_Mutex.cpp
+++ b/ACE/ace/Condition_Recursive_Thread_Mutex.cpp
@@ -12,15 +12,15 @@
 
 #if defined (ACE_HAS_THREADS)
 
+#if !defined (__ACE_INLINE__)
+#include "ace/Condition_Recursive_Thread_Mutex.inl"
+#endif /* __ACE_INLINE__ */
+
 #include "ace/Log_Category.h"
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
-int
-ACE_Condition<ACE_Recursive_Thread_Mutex>::remove (void)
-{
-  return ACE_OS::cond_destroy (&this->cond_);
-}
+ACE_ALLOC_HOOK_DEFINE (ACE_Condition<ACE_Recursive_Thread_Mutex>)
 
 void
 ACE_Condition<ACE_Recursive_Thread_Mutex>::dump (void) const
@@ -35,11 +35,6 @@ ACE_Condition<ACE_Recursive_Thread_Mutex>::dump (void) const
   ACELIB_DEBUG ((LM_DEBUG, ACE_TEXT ("\n")));
   ACELIB_DEBUG ((LM_DEBUG, ACE_END_DUMP));
 #endif /* ACE_HAS_DUMP */
-}
-
-ACE_Condition<ACE_Recursive_Thread_Mutex>::~ACE_Condition (void)
-{
-  this->remove ();
 }
 
 ACE_Condition<ACE_Recursive_Thread_Mutex>::ACE_Condition (ACE_Recursive_Thread_Mutex &m)
@@ -58,6 +53,11 @@ ACE_Condition<ACE_Recursive_Thread_Mutex>::ACE_Condition (ACE_Recursive_Thread_M
                          const_cast<ACE_condattr_t &> (attributes.attributes ())) != 0)
     ACELIB_ERROR ((LM_ERROR, ACE_TEXT ("%p\n"),
                 ACE_TEXT ("ACE_Condition<ACE_Recursive_Thread_Mutex>::ACE_Condition<ACE_Recursive_Thread_Mutex>")));
+}
+
+ACE_Condition<ACE_Recursive_Thread_Mutex>::~ACE_Condition (void)
+{
+  this->remove ();
 }
 
 int
@@ -118,12 +118,6 @@ int
 ACE_Condition<ACE_Recursive_Thread_Mutex>::broadcast (void)
 {
   return ACE_OS::cond_broadcast (&this->cond_);
-}
-
-ACE_Recursive_Thread_Mutex &
-ACE_Condition<ACE_Recursive_Thread_Mutex>::mutex (void)
-{
-  return this->mutex_;
 }
 
 ACE_END_VERSIONED_NAMESPACE_DECL

--- a/ACE/ace/Condition_Recursive_Thread_Mutex.h
+++ b/ACE/ace/Condition_Recursive_Thread_Mutex.h
@@ -110,13 +110,11 @@ private:
 };
 // prevent implicit instantiations by includers to relieve the linker
 #if defined (ACE_HAS_CPP11_EXTERN_TEMPLATES)
-// suppress a warning, g++ 5.2.1 does not support attributes on template
-// instantiation declarations. *TODO*: this may go back further
-# if defined (__GNUG__) && (__GNUC__ == 5 && __GNUC_MINOR__ == 2 && __GNUC_PATCHLEVEL__ == 1)
+# if defined (ACE_LACKS_CPP11_EXTERN_TEMPLATE_ATTRIBUTES)
 extern template class ACE_Condition<ACE_Recursive_Thread_Mutex>;
 # else
 extern template ACE_Export class ACE_Condition<ACE_Recursive_Thread_Mutex>;
-# endif /* __GNUG__ && (__GNUC__ == 5 && __GNUC_MINOR__ == 2 && __GNUC_PATCHLEVEL__ == 1) */
+# endif /* ACE_LACKS_CPP11_EXTERN_TEMPLATE_ATTRIBUTES */
 #endif /* ACE_HAS_CPP11_EXTERN_TEMPLATES */
 
 typedef ACE_Condition<ACE_Recursive_Thread_Mutex> ACE_Condition_Recursive_Thread_Mutex;

--- a/ACE/ace/Condition_Recursive_Thread_Mutex.h
+++ b/ACE/ace/Condition_Recursive_Thread_Mutex.h
@@ -108,13 +108,16 @@ private:
   ACE_Recursive_Thread_Mutex &mutex_;
 
 };
-// *NOTE*: prevent implicit instantiations by includees to relieve the linker
-#if defined (__GNUG__)
-// g++ (5.2.1) does not support attributes on explicit template instantiations
+// prevent implicit instantiations by includers to relieve the linker
+#if defined (ACE_HAS_CPP11_EXTERN_TEMPLATES)
+// suppress a warning, g++ 5.2.1 does not support attributes on template
+// instantiation declarations. *TODO*: this may go back further
+# if defined (__GNUG__) && (__GNUC__ == 5 && __GNUC_MINOR__ == 2 && __GNUC_PATCHLEVEL__ == 1)
 extern template class ACE_Condition<ACE_Recursive_Thread_Mutex>;
-#else
+# else
 extern template ACE_Export class ACE_Condition<ACE_Recursive_Thread_Mutex>;
-#endif /* __GNUG__ */
+# endif /* __GNUG__ && (__GNUC__ == 5 && __GNUC_MINOR__ == 2 && __GNUC_PATCHLEVEL__ == 1) */
+#endif /* ACE_HAS_CPP11_EXTERN_TEMPLATES */
 
 typedef ACE_Condition<ACE_Recursive_Thread_Mutex> ACE_Condition_Recursive_Thread_Mutex;
 

--- a/ACE/ace/Condition_Recursive_Thread_Mutex.h
+++ b/ACE/ace/Condition_Recursive_Thread_Mutex.h
@@ -33,7 +33,6 @@ ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
 class ACE_Time_Value;
 
-#if defined (ACE_BUILD_DLL)
 /**
  * @brief ACE_Condition template specialization written using
  *  @a ACE_Recursive_Thread_Mutex.  This allows threads to block until
@@ -109,9 +108,13 @@ private:
   ACE_Recursive_Thread_Mutex &mutex_;
 
 };
+// *NOTE*: prevent implicit instantiations by includees to relieve the linker
+#if defined (__GNUG__)
+// g++ (5.2.1) does not support attributes on explicit template instantiations
+extern template class ACE_Condition<ACE_Recursive_Thread_Mutex>;
 #else
 extern template ACE_Export class ACE_Condition<ACE_Recursive_Thread_Mutex>;
-#endif
+#endif /* __GNUG__ */
 
 typedef ACE_Condition<ACE_Recursive_Thread_Mutex> ACE_Condition_Recursive_Thread_Mutex;
 

--- a/ACE/ace/Condition_Recursive_Thread_Mutex.h
+++ b/ACE/ace/Condition_Recursive_Thread_Mutex.h
@@ -23,12 +23,17 @@
 #if !defined (ACE_HAS_THREADS)
 #  include "ace/Null_Condition.h"
 #else /* ACE_HAS_THREADS */
+// ACE platform supports some form of threading.
+
 #include "ace/Recursive_Thread_Mutex.h"
 #include "ace/Condition_Attributes.h"
 #include "ace/Condition_T.h"
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
+class ACE_Time_Value;
+
+#if defined (ACE_BUILD_DLL)
 /**
  * @brief ACE_Condition template specialization written using
  *  @a ACE_Recursive_Thread_Mutex.  This allows threads to block until
@@ -86,6 +91,9 @@ public:
   /// Dump the state of an object.
   void dump (void) const;
 
+  /// Declare the dynamic allocation hooks.
+  ACE_ALLOC_HOOK_DECLARE;
+
 private:
 
   // = Prevent assignment and copying.
@@ -101,10 +109,17 @@ private:
   ACE_Recursive_Thread_Mutex &mutex_;
 
 };
+#else
+extern template ACE_Export class ACE_Condition<ACE_Recursive_Thread_Mutex>;
+#endif
 
 typedef ACE_Condition<ACE_Recursive_Thread_Mutex> ACE_Condition_Recursive_Thread_Mutex;
 
 ACE_END_VERSIONED_NAMESPACE_DECL
+
+#if defined (__ACE_INLINE__)
+#include "ace/Condition_Recursive_Thread_Mutex.inl"
+#endif /* __ACE_INLINE__ */
 
 #endif /* !ACE_HAS_THREADS */
 

--- a/ACE/ace/Condition_Recursive_Thread_Mutex.inl
+++ b/ACE/ace/Condition_Recursive_Thread_Mutex.inl
@@ -13,4 +13,16 @@ ACE_Condition<ACE_Recursive_Thread_Mutex>::mutex (void)
   return this->mutex_;
 }
 
+ACE_INLINE int
+ACE_Condition<ACE_Recursive_Thread_Mutex>::signal (void)
+{
+  return ACE_OS::cond_signal (&this->cond_);
+}
+
+ACE_INLINE int
+ACE_Condition<ACE_Recursive_Thread_Mutex>::broadcast (void)
+{
+  return ACE_OS::cond_broadcast (&this->cond_);
+}
+
 ACE_END_VERSIONED_NAMESPACE_DECL

--- a/ACE/ace/Condition_Recursive_Thread_Mutex.inl
+++ b/ACE/ace/Condition_Recursive_Thread_Mutex.inl
@@ -1,0 +1,16 @@
+// -*- C++ -*-
+ACE_BEGIN_VERSIONED_NAMESPACE_DECL
+
+ACE_INLINE int
+ACE_Condition<ACE_Recursive_Thread_Mutex>::remove (void)
+{
+  return ACE_OS::cond_destroy (&this->cond_);
+}
+
+ACE_INLINE ACE_Recursive_Thread_Mutex &
+ACE_Condition<ACE_Recursive_Thread_Mutex>::mutex (void)
+{
+  return this->mutex_;
+}
+
+ACE_END_VERSIONED_NAMESPACE_DECL

--- a/ACE/ace/Connector.h
+++ b/ACE/ace/Connector.h
@@ -13,12 +13,14 @@
 
 #include /**/ "ace/pre.h"
 
+#include "ace/Event_Handler.h"
 #include "ace/Service_Object.h"
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 # pragma once
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
+#include "ace/Reactor.h"
 #include "ace/Strategies_T.h"
 #include "ace/Synch_Options.h"
 #include "ace/Unbounded_Set.h"

--- a/ACE/ace/Event_Handler.cpp
+++ b/ACE/ace/Event_Handler.cpp
@@ -1,10 +1,12 @@
 // Event_Handler.cpp
 #include "ace/Event_Handler.h"
-#include "ace/OS_Errno.h"
-#include "ace/Reactor.h"
-#include "ace/Thread_Manager.h"
+
 /* Need to see if ACE_HAS_BUILTIN_ATOMIC_OP defined */
 #include "ace/Atomic_Op.h"
+#include "ace/OS_Errno.h"
+#include "ace/Reactor.h"
+#include "ace/Synch.h"
+#include "ace/Thread_Manager.h"
 
 #if !defined (__ACE_INLINE__)
 #include "ace/Event_Handler.inl"

--- a/ACE/ace/Event_Handler.h
+++ b/ACE/ace/Event_Handler.h
@@ -22,6 +22,7 @@
 #include "ace/Atomic_Op.h"
 #include "ace/OS_NS_Thread.h"
 #include "ace/Synch_Traits.h"
+#include "ace/Time_Value.h"
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 

--- a/ACE/ace/Event_Handler_Handle_Timeout_Upcall.cpp
+++ b/ACE/ace/Event_Handler_Handle_Timeout_Upcall.cpp
@@ -1,6 +1,7 @@
 #include "ace/Event_Handler_Handle_Timeout_Upcall.h"
-#include "ace/Reactor_Timer_Interface.h"
+
 #include "ace/Abstract_Timer_Queue.h"
+#include "ace/Reactor_Timer_Interface.h"
 
 #if !defined(__ACE_INLINE__)
 # include "ace/Event_Handler_Handle_Timeout_Upcall.inl"
@@ -10,24 +11,22 @@ ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
 ACE_ALLOC_HOOK_DEFINE(ACE_Event_Handler_Handle_Timeout_Upcall)
 
-ACE_Event_Handler_Handle_Timeout_Upcall::
-ACE_Event_Handler_Handle_Timeout_Upcall (void) :
-  requires_reference_counting_ (0)
+ACE_Event_Handler_Handle_Timeout_Upcall::ACE_Event_Handler_Handle_Timeout_Upcall (void)
+ : requires_reference_counting_ (0)
 {
 }
 
-ACE_Event_Handler_Handle_Timeout_Upcall::
-~ACE_Event_Handler_Handle_Timeout_Upcall (void)
+ACE_Event_Handler_Handle_Timeout_Upcall::~ACE_Event_Handler_Handle_Timeout_Upcall (void)
 {
 }
 
 int
-ACE_Event_Handler_Handle_Timeout_Upcall::
-timeout (ACE_Timer_Queue &timer_queue,
-        ACE_Event_Handler *event_handler,
-        const void *act,
-        int recurring_timer,
-        const ACE_Time_Value &cur_time)
+ACE_Event_Handler_Handle_Timeout_Upcall::timeout (
+  ACE_Timer_Queue &timer_queue,
+  ACE_Event_Handler *event_handler,
+  const void *act,
+  int recurring_timer,
+  const ACE_Time_Value &cur_time)
 {
   int requires_reference_counting = 0;
 
@@ -57,11 +56,11 @@ timeout (ACE_Timer_Queue &timer_queue,
 }
 
 int
-ACE_Event_Handler_Handle_Timeout_Upcall::
-cancel_type (ACE_Timer_Queue &,
-            ACE_Event_Handler *event_handler,
-            int dont_call,
-            int &requires_reference_counting)
+ACE_Event_Handler_Handle_Timeout_Upcall::cancel_type (
+  ACE_Timer_Queue &,
+  ACE_Event_Handler *event_handler,
+  int dont_call,
+  int &requires_reference_counting)
 {
   requires_reference_counting =
     event_handler->reference_counting_policy ().value () ==
@@ -76,10 +75,10 @@ cancel_type (ACE_Timer_Queue &,
 }
 
 int
-ACE_Event_Handler_Handle_Timeout_Upcall::
-deletion (ACE_Timer_Queue &timer_queue,
-          ACE_Event_Handler *event_handler,
-          const void *)
+ACE_Event_Handler_Handle_Timeout_Upcall::deletion (
+  ACE_Timer_Queue &timer_queue,
+  ACE_Event_Handler *event_handler,
+  const void *)
 {
   int requires_reference_counting = 0;
 

--- a/ACE/ace/Event_Handler_Handle_Timeout_Upcall.h
+++ b/ACE/ace/Event_Handler_Handle_Timeout_Upcall.h
@@ -12,8 +12,9 @@
  * Brunsch, Irfan Pyarali and a cast of thousands.
  */
 
-#include "ace/Timer_Queuefwd.h"
 #include "ace/Copy_Disabled.h"
+#include "ace/Timer_Queuefwd.h"
+#include "ace/Timer_Queue_T.h"
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -28,7 +29,7 @@ class ACE_Time_Value;
  * Queue to call <handle_timeout> on ACE_Event_Handlers.
  */
 class ACE_Export ACE_Event_Handler_Handle_Timeout_Upcall
-  : private ACE_Copy_Disabled
+ : private ACE_Copy_Disabled
 {
 public:
   // = Initialization and termination methods.

--- a/ACE/ace/Event_Handler_Handle_Timeout_Upcall.inl
+++ b/ACE/ace/Event_Handler_Handle_Timeout_Upcall.inl
@@ -3,23 +3,23 @@
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
 ACE_INLINE int
-ACE_Event_Handler_Handle_Timeout_Upcall::
-registration (ACE_Timer_Queue &,
-              ACE_Event_Handler *event_handler,
-              const void *)
+ACE_Event_Handler_Handle_Timeout_Upcall::registration (
+  ACE_Timer_Queue &,
+  ACE_Event_Handler *event_handler,
+  const void *)
 {
   event_handler->add_reference ();
   return 0;
 }
 
 ACE_INLINE int
-ACE_Event_Handler_Handle_Timeout_Upcall::
-preinvoke (ACE_Timer_Queue &,
-          ACE_Event_Handler *event_handler,
-          const void *,
-          int,
-          const ACE_Time_Value &,
-          const void * & upcall_act)
+ACE_Event_Handler_Handle_Timeout_Upcall::preinvoke (
+  ACE_Timer_Queue &,
+  ACE_Event_Handler *event_handler,
+  const void *,
+  int,
+  const ACE_Time_Value &,
+  const void *&upcall_act)
 {
   bool const requires_reference_counting =
     event_handler->reference_counting_policy ().value () ==
@@ -36,13 +36,13 @@ preinvoke (ACE_Timer_Queue &,
 }
 
 ACE_INLINE int
-ACE_Event_Handler_Handle_Timeout_Upcall::
-postinvoke (ACE_Timer_Queue & /* timer_queue */,
-            ACE_Event_Handler *event_handler,
-            const void * /* timer_act */,
-            int /* recurring_timer */,
-            const ACE_Time_Value & /* cur_time */,
-            const void *upcall_act)
+ACE_Event_Handler_Handle_Timeout_Upcall::postinvoke (
+  ACE_Timer_Queue & /* timer_queue */,
+  ACE_Event_Handler *event_handler,
+  const void * /* timer_act */,
+  int /* recurring_timer */,
+  const ACE_Time_Value & /* cur_time */,
+  const void *upcall_act)
 {
   if (upcall_act == &this->requires_reference_counting_)
     {
@@ -53,11 +53,11 @@ postinvoke (ACE_Timer_Queue & /* timer_queue */,
 }
 
 ACE_INLINE int
-ACE_Event_Handler_Handle_Timeout_Upcall::
-cancel_timer (ACE_Timer_Queue &,
-              ACE_Event_Handler *event_handler,
-              int,
-              int requires_reference_counting)
+ACE_Event_Handler_Handle_Timeout_Upcall::cancel_timer (
+  ACE_Timer_Queue &,
+  ACE_Event_Handler *event_handler,
+  int,
+  int requires_reference_counting)
 {
   if (requires_reference_counting)
     event_handler->remove_reference ();

--- a/ACE/ace/Free_List.cpp
+++ b/ACE/ace/Free_List.cpp
@@ -62,6 +62,8 @@ ACE_Locked_Free_List<T, ACE_LOCK>::add (T *element)
 {
   ACE_MT (ACE_GUARD (ACE_LOCK, ace_mon, this->mutex_));
 
+  ACE_ASSERT (element != 0);
+
   // Check to see that we not at the high water mark.
   if (this->mode_ == ACE_PURE_FREE_LIST
       || this->size_ < this->hwm_)

--- a/ACE/ace/Future.h
+++ b/ACE/ace/Future.h
@@ -26,8 +26,6 @@
 #if defined (ACE_HAS_THREADS)
 
 #include "ace/Synch_Traits.h"
-#include "ace/Recursive_Thread_Mutex.h"
-#include "ace/Condition_Recursive_Thread_Mutex.h"
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 

--- a/ACE/ace/Log_Msg.cpp
+++ b/ACE/ace/Log_Msg.cpp
@@ -8,7 +8,6 @@
 #define ACE_NTRACE 1
 
 #include "ace/ACE.h"
-#include "ace/Thread_Manager.h"
 #include "ace/Guard_T.h"
 #include "ace/OS_NS_stdio.h"
 #include "ace/OS_NS_errno.h"
@@ -16,6 +15,9 @@
 #include "ace/OS_NS_string.h"
 #include "ace/OS_NS_wchar.h"
 #include "ace/OS_NS_signal.h"
+#include "ace/Synch.h"
+#include "ace/Thread_Manager.h"
+
 #include "ace/os_include/os_typeinfo.h"
 
 #if !defined (ACE_MT_SAFE) || (ACE_MT_SAFE != 0)

--- a/ACE/ace/Message_Queue_T.h
+++ b/ACE/ace/Message_Queue_T.h
@@ -13,15 +13,15 @@
 
 #include /**/ "ace/pre.h"
 
-#include "ace/Message_Queue.h"
-#include "ace/Dynamic_Message_Strategy.h"
-#include "ace/Synch_Traits.h"
-#include "ace/Guard_T.h"
-#include "ace/Time_Policy.h"
-#include "ace/Time_Value_T.h"
 #if defined (ACE_HAS_THREADS)
 # include "ace/Condition_Attributes.h"
 #endif
+#include "ace/Dynamic_Message_Strategy.h"
+#include "ace/Guard_T.h"
+#include "ace/Message_Queue.h"
+#include "ace/Synch_Traits.h"
+#include "ace/Time_Policy.h"
+#include "ace/Time_Value_T.h"
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 # pragma once

--- a/ACE/ace/NT_Service.cpp
+++ b/ACE/ace/NT_Service.cpp
@@ -1,6 +1,7 @@
 #include "ace/config-all.h"
 #if defined (ACE_WIN32) && !defined (ACE_LACKS_WIN32_SERVICES)
 
+#include "ace/Synch.h"
 #include "ace/NT_Service.h"
 
 #if !defined (__ACE_INLINE__)

--- a/ACE/ace/OS_NS_pwd.inl
+++ b/ACE/ace/OS_NS_pwd.inl
@@ -56,6 +56,14 @@ ACE_OS::getpwnam_r (const char *name,
     }
   *result = pwd;
   return 0;
+#elif defined (ACE_HAS_SOLARIS11_GETPWNAM_R)
+  if (::getpwnam_r (name, pwd, buffer, bufsize) == 0)
+  {
+    *result = 0;
+    return -1;
+  }
+  *result = pwd;
+  return 0;
 #elif defined (ACE_HAS_STHREADS)
   if (::getpwnam_r (name, pwd, buffer, bufsize) != 0)
     {

--- a/ACE/ace/Object_Manager.cpp
+++ b/ACE/ace/Object_Manager.cpp
@@ -1,20 +1,22 @@
 #include "ace/Object_Manager.h"
-#if !defined (ACE_LACKS_ACE_TOKEN)
-# include "ace/Token_Manager.h"
-#endif /* ! ACE_LACKS_ACE_TOKEN */
-#include "ace/Thread_Manager.h"
+
+#include "ace/Atomic_Op.h"
+#include "ace/DLL_Manager.h"
+#include "ace/Framework_Component.h"
+#include "ace/Guard_T.h"
+#include "ace/Malloc.h"
+#include "ace/OS_NS_sys_time.h"
 #if !defined (ACE_LACKS_ACE_SVCCONF)
 # include "ace/Service_Manager.h"
 # include "ace/Service_Config.h"
 #endif /* ! ACE_LACKS_ACE_SVCCONF */
-#include "ace/Signal.h"
-#include "ace/Log_Category.h"
-#include "ace/Malloc.h"
 #include "ace/Sig_Adapter.h"
-#include "ace/Framework_Component.h"
-#include "ace/DLL_Manager.h"
-#include "ace/Atomic_Op.h"
-#include "ace/OS_NS_sys_time.h"
+#include "ace/Signal.h"
+#include "ace/Synch.h"
+#if !defined (ACE_LACKS_ACE_TOKEN)
+# include "ace/Token_Manager.h"
+#endif /* ! ACE_LACKS_ACE_TOKEN */
+#include "ace/Thread_Manager.h"
 
 #if defined (ACE_HAS_TRACE)
 #include "ace/Trace.h"
@@ -24,12 +26,8 @@
 # include "ace/Object_Manager.inl"
 #endif /* __ACE_INLINE__ */
 
-#include "ace/Guard_T.h"
-#include "ace/Null_Mutex.h"
-#include "ace/Mutex.h"
-#include "ace/RW_Thread_Mutex.h"
 #if defined (ACE_DISABLE_WIN32_ERROR_WINDOWS) && !defined (ACE_HAS_WINCE)
-  #include "ace/OS_NS_stdlib.h"
+# include "ace/OS_NS_stdlib.h"
 #endif // ACE_DISABLE_WIN32_ERROR_WINDOWS
 
 #if ! defined (ACE_APPLICATION_PREALLOCATED_OBJECT_DEFINITIONS)

--- a/ACE/ace/Parse_Node.cpp
+++ b/ACE/ace/Parse_Node.cpp
@@ -2,14 +2,15 @@
 
 #if (ACE_USES_CLASSIC_SVC_CONF == 1)
 
+#include "ace/ACE.h"
+#include "ace/ARGV.h"
+#include "ace/DLL.h"
+#include "ace/OS_NS_string.h"
 #include "ace/Service_Config.h"
 #include "ace/Service_Repository.h"
 #include "ace/Service_Types.h"
+#include "ace/Svc_Conf.h"
 #include "ace/Task.h"
-#include "ace/DLL.h"
-#include "ace/ACE.h"
-#include "ace/OS_NS_string.h"
-#include "ace/ARGV.h"
 
 #include <list>
 

--- a/ACE/ace/Parse_Node.h
+++ b/ACE/ace/Parse_Node.h
@@ -22,14 +22,15 @@
 
 #if (ACE_USES_CLASSIC_SVC_CONF == 1)
 
+#include "ace/Auto_Ptr.h"
 #include "ace/DLL.h"
 #include "ace/SString.h"
-#include "ace/Svc_Conf.h"
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
 /// Forward declarations.
 class ACE_Service_Config;
+class ACE_Service_Gestalt;
 class ACE_Service_Type;
 
 /**
@@ -503,7 +504,7 @@ private:
     (ACE_Service_Type_Factory(const ACE_Service_Type_Factory&))
 
   ACE_UNIMPLEMENTED_FUNC
-    (ACE_Service_Type_Factory& operator=(const ACE_Service_Type_Factory&))
+    (ACE_Service_Type_Factory& operator= (const ACE_Service_Type_Factory&))
 
 private:
   ACE_TString name_;

--- a/ACE/ace/Priority_Reactor.cpp
+++ b/ACE/ace/Priority_Reactor.cpp
@@ -1,7 +1,7 @@
+#include "ace/Synch.h"
 #include "ace/Priority_Reactor.h"
+
 #include "ace/Malloc_T.h"
-
-
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 

--- a/ACE/ace/Proactor.cpp
+++ b/ACE/ace/Proactor.cpp
@@ -1,23 +1,22 @@
 #include /**/ "ace/config-lite.h"
+
+#include "ace/Synch.h"
 #include "ace/Proactor.h"
+
 #if defined (ACE_HAS_WIN32_OVERLAPPED_IO) || defined (ACE_HAS_AIO_CALLS)
 
 // This only works on Win32 platforms and on Unix platforms with aio
 // calls.
-
+#include "ace/Auto_Event.h"
 #include "ace/Auto_Ptr.h"
-#include "ace/Proactor_Impl.h"
+#include "ace/Framework_Component.h"
+#include "ace/Log_Category.h"
 #include "ace/Object_Manager.h"
-#include "ace/Task_T.h"
-
+#include "ace/Proactor_Impl.h"
 #if !defined (ACE_HAS_WINCE) && !defined (ACE_LACKS_ACE_SVCCONF)
 #    include "ace/Service_Config.h"
 #endif /* !ACE_HAS_WINCE && !ACE_LACKS_ACE_SVCCONF */
-
-
 #include "ace/Task_T.h"
-#include "ace/Log_Category.h"
-#include "ace/Framework_Component.h"
 
 #if defined (ACE_HAS_AIO_CALLS)
 #   include "ace/POSIX_Proactor.h"
@@ -29,8 +28,6 @@
 #if !defined (__ACE_INLINE__)
 #include "ace/Proactor.inl"
 #endif /* __ACE_INLINE__ */
-
-#include "ace/Auto_Event.h"
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -185,10 +182,10 @@ ACE_Proactor_Handle_Timeout_Upcall::ACE_Proactor_Handle_Timeout_Upcall (void)
 
 int
 ACE_Proactor_Handle_Timeout_Upcall::registration (ACE_Proactor_Timer_Queue &,
-                                                  ACE_Handler * handler,
+                                                  ACE_Handler *handler,
                                                   const void *)
 {
-  handler->proactor(proactor_);
+  handler->proactor (proactor_);
   return 0;
 }
 
@@ -403,7 +400,7 @@ ACE_Proactor::instance (ACE_Proactor * r, bool delete_proactor)
 
   ACE_Proactor::delete_proactor_ = delete_proactor;
   ACE_Proactor::proactor_ = r;
-  ACE_REGISTER_FRAMEWORK_COMPONENT(ACE_Proactor, ACE_Proactor::proactor_);
+  ACE_REGISTER_FRAMEWORK_COMPONENT (ACE_Proactor, ACE_Proactor::proactor_);
 
   return t;
 }
@@ -654,7 +651,7 @@ ACE_Proactor::register_handle (ACE_HANDLE handle,
 }
 
 long
-ACE_Proactor::schedule_timer (ACE_Handler &handler,
+ACE_Proactor::schedule_timer (ACE_Handler *handler,
                               const void *act,
                               const ACE_Time_Value &time)
 {
@@ -665,7 +662,7 @@ ACE_Proactor::schedule_timer (ACE_Handler &handler,
 }
 
 long
-ACE_Proactor::schedule_repeating_timer (ACE_Handler &handler,
+ACE_Proactor::schedule_repeating_timer (ACE_Handler *handler,
                                         const void *act,
                                         const ACE_Time_Value &interval)
 {
@@ -676,7 +673,7 @@ ACE_Proactor::schedule_repeating_timer (ACE_Handler &handler,
 }
 
 long
-ACE_Proactor::schedule_timer (ACE_Handler &handler,
+ACE_Proactor::schedule_timer (ACE_Handler *handler,
                               const void *act,
                               const ACE_Time_Value &time,
                               const ACE_Time_Value &interval)
@@ -684,7 +681,7 @@ ACE_Proactor::schedule_timer (ACE_Handler &handler,
   // absolute time.
   ACE_Time_Value absolute_time =
     this->timer_queue_->gettimeofday () + time;
-  long result = this->timer_queue_->schedule (&handler,
+  long result = this->timer_queue_->schedule (handler,
                                               act,
                                               absolute_time,
                                               interval);
@@ -711,12 +708,12 @@ ACE_Proactor::cancel_timer (long timer_id,
 }
 
 int
-ACE_Proactor::cancel_timer (ACE_Handler &handler,
-                                  int dont_call_handle_close)
+ACE_Proactor::cancel_timer (ACE_Handler *handler,
+                            int dont_call_handle_close)
 {
   // No need to signal timer event here. Even if the cancel timer was
   // the earliest, we will have an extra wakeup.
-  return this->timer_queue_->cancel (&handler,
+  return this->timer_queue_->cancel (handler,
                                      dont_call_handle_close);
 }
 
@@ -790,7 +787,7 @@ ACE_Proactor::timer_queue (ACE_Proactor_Timer_Queue *tq)
     }
 
   // Set the proactor in the timer queue's functor
-  typedef ACE_Timer_Queue_Upcall_Base<ACE_Handler*,ACE_Proactor_Handle_Timeout_Upcall> TQ_Base;
+  typedef ACE_Timer_Queue_Upcall_Base<ACE_Proactor_Handle_Timeout_Upcall> TQ_Base;
 
   TQ_Base * tqb = dynamic_cast<TQ_Base*> (this->timer_queue_);
 
@@ -977,7 +974,7 @@ ACE_Proactor::create_asynch_read_dgram_result
    int priority,
    int signal_number)
 {
-  return this->implementation()->create_asynch_read_dgram_result
+  return this->implementation ()->create_asynch_read_dgram_result
     (handler_proxy,
      handle,
      message_block,
@@ -1002,7 +999,7 @@ ACE_Proactor::create_asynch_write_dgram_result
    int priority,
    int signal_number)
 {
-  return this->implementation()->create_asynch_write_dgram_result
+  return this->implementation ()->create_asynch_write_dgram_result
     (handler_proxy,
      handle,
      message_block,

--- a/ACE/ace/Proactor.h
+++ b/ACE/ace/Proactor.h
@@ -42,7 +42,7 @@ class ACE_Proactor_Impl;
 class ACE_Proactor_Timer_Handler;
 
 /// Type def for the timer queue.
-typedef ACE_Abstract_Timer_Queue<ACE_Handler *> ACE_Proactor_Timer_Queue;
+typedef ACE_Abstract_Timer_Queue<ACE_Handler> ACE_Proactor_Timer_Queue;
 
 /**
  * @class ACE_Proactor_Handle_Timeout_Upcall
@@ -129,31 +129,37 @@ class ACE_Export ACE_Proactor
 {
   // = Here are the private typedefs that the ACE_Proactor uses.
 
-  typedef ACE_Timer_Queue_Iterator_T<ACE_Handler *>
+  typedef ACE_Timer_Queue_Iterator_T<ACE_Handler>
     TIMER_QUEUE_ITERATOR;
-  typedef ACE_Timer_List_T<ACE_Handler *,
+  typedef ACE_Timer_List_T<ACE_Handler,
     ACE_Proactor_Handle_Timeout_Upcall,
-    ACE_SYNCH_RECURSIVE_MUTEX>
+    ACE_SYNCH_RECURSIVE_MUTEX,
+    ACE_Default_Time_Policy>
   TIMER_LIST;
-  typedef ACE_Timer_List_Iterator_T<ACE_Handler *,
+  typedef ACE_Timer_List_Iterator_T<ACE_Handler,
     ACE_Proactor_Handle_Timeout_Upcall,
-    ACE_SYNCH_RECURSIVE_MUTEX>
+    ACE_SYNCH_RECURSIVE_MUTEX,
+    ACE_Default_Time_Policy>
   TIMER_LIST_ITERATOR;
-  typedef ACE_Timer_Heap_T<ACE_Handler *,
+  typedef ACE_Timer_Heap_T<ACE_Handler,
     ACE_Proactor_Handle_Timeout_Upcall,
-    ACE_SYNCH_RECURSIVE_MUTEX>
+    ACE_SYNCH_RECURSIVE_MUTEX,
+    ACE_Default_Time_Policy>
   TIMER_HEAP;
-  typedef ACE_Timer_Heap_Iterator_T<ACE_Handler *,
+  typedef ACE_Timer_Heap_Iterator_T<ACE_Handler,
     ACE_Proactor_Handle_Timeout_Upcall,
-    ACE_SYNCH_RECURSIVE_MUTEX>
+    ACE_SYNCH_RECURSIVE_MUTEX,
+    ACE_Default_Time_Policy>
   TIMER_HEAP_ITERATOR;
-  typedef ACE_Timer_Wheel_T<ACE_Handler *,
+  typedef ACE_Timer_Wheel_T<ACE_Handler,
     ACE_Proactor_Handle_Timeout_Upcall,
-    ACE_SYNCH_RECURSIVE_MUTEX>
+    ACE_SYNCH_RECURSIVE_MUTEX,
+    ACE_Default_Time_Policy>
   TIMER_WHEEL;
-  typedef ACE_Timer_Wheel_Iterator_T<ACE_Handler *,
+  typedef ACE_Timer_Wheel_Iterator_T<ACE_Handler,
     ACE_Proactor_Handle_Timeout_Upcall,
-    ACE_SYNCH_RECURSIVE_MUTEX>
+    ACE_SYNCH_RECURSIVE_MUTEX,
+    ACE_Default_Time_Policy>
   TIMER_WHEEL_ITERATOR;
 
   // = Friendship.
@@ -182,7 +188,7 @@ public:
 
   /// Set pointer to a process-wide ACE_Proactor and return existing
   /// pointer.
-  static ACE_Proactor *instance (ACE_Proactor * proactor,
+  static ACE_Proactor *instance (ACE_Proactor *proactor,
                                  bool delete_proactor = false);
 
   /// Delete the dynamically allocated Singleton.
@@ -301,11 +307,11 @@ public:
    * with accidentally deleting the wrong timer.  Returns -1 on
    * failure (which is guaranteed never to be a valid <timer_id>).
    */
-  long schedule_timer (ACE_Handler &handler,
+  long schedule_timer (ACE_Handler *handler,
                        const void *act,
                        const ACE_Time_Value &time);
 
-  long schedule_repeating_timer (ACE_Handler &handler,
+  long schedule_repeating_timer (ACE_Handler *handler,
                                  const void *act,
                                  const ACE_Time_Value &interval);
 
@@ -314,14 +320,14 @@ public:
 
   /// This combines the above two methods into one. Mostly for backward
   /// compatibility.
-  long schedule_timer (ACE_Handler &handler,
+  long schedule_timer (ACE_Handler *handler,
                        const void *act,
                        const ACE_Time_Value &time,
                        const ACE_Time_Value &interval);
 
   /// Cancel all timers associated with this @a handler.  Returns number
   /// of timers cancelled.
-  int cancel_timer (ACE_Handler &handler,
+  int cancel_timer (ACE_Handler *handler,
                     int dont_call_handle_close = 1);
 
   /**

--- a/ACE/ace/Service_Gestalt.cpp
+++ b/ACE/ace/Service_Gestalt.cpp
@@ -1,31 +1,30 @@
-#include "ace/Svc_Conf.h"
-#include "ace/Get_Opt.h"
+#include "ace/Service_Gestalt.h"
+
 #include "ace/ARGV.h"
+#include "ace/Auto_Ptr.h"
+#include "ace/Containers.h"
+#include "ace/DLL.h"
+#include "ace/Get_Opt.h"
 #include "ace/Malloc.h"
+#include "ace/Reactor.h"
 #include "ace/Service_Manager.h"
 #include "ace/Service_Types.h"
-#include "ace/Containers.h"
-#include "ace/Auto_Ptr.h"
-#include "ace/Reactor.h"
-#include "ace/Thread_Manager.h"
-#include "ace/DLL.h"
-#include "ace/XML_Svc_Conf.h"
-#include "ace/SString.h"
-
 #ifndef ACE_LACKS_UNIX_SIGNALS
 # include "ace/Signal.h"
 #endif  /* !ACE_LACKS_UNIX_SIGNALS */
+#include "ace/SString.h"
+#include "ace/Svc_Conf.h"
+#include "ace/Svc_Conf_Param.h"
+#include "ace/Synch.h"
+#include "ace/Thread_Manager.h"
+#include "ace/TSS_T.h"
+#include "ace/XML_Svc_Conf.h"
 
 #include "ace/OS_NS_stdio.h"
 #include "ace/OS_NS_string.h"
 #include "ace/OS_NS_time.h"
 #include "ace/OS_NS_unistd.h"
 #include "ace/OS_NS_sys_stat.h"
-
-#include "ace/TSS_T.h"
-#include "ace/Service_Gestalt.h"
-
-#include "ace/Svc_Conf_Param.h"
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 

--- a/ACE/ace/Strategies_T.cpp
+++ b/ACE/ace/Strategies_T.cpp
@@ -1385,6 +1385,19 @@ ACE_Scheduling_Strategy<SVC_HANDLER>::dump (void) const
 #endif /* ACE_HAS_DUMP */
 }
 
+template <class SVC_HANDLER> ACE_INLINE
+ACE_Schedule_All_Threaded_Strategy<SVC_HANDLER>::ACE_Schedule_All_Threaded_Strategy
+(SVC_HANDLER *scheduler)
+  : ACE_Scheduling_Strategy<SVC_HANDLER> (scheduler)
+{
+  ACE_TRACE ("ACE_Schedule_All_Threaded_Strategy<SVC_HANDLER>::ACE_Schedule_All_Threaded_Strategy");
+
+  if (scheduler == 0 || scheduler->thr_mgr () == 0)
+    this->thr_mgr_ = ACE_Thread_Manager::instance ();
+  else
+    this->thr_mgr_ = scheduler->thr_mgr ();
+}
+
 template <class SVC_HANDLER> int
 ACE_Schedule_All_Reactive_Strategy<SVC_HANDLER>::suspend (void)
 {

--- a/ACE/ace/Strategies_T.h
+++ b/ACE/ace/Strategies_T.h
@@ -13,17 +13,15 @@
 
 #include /**/ "ace/pre.h"
 
-#include "ace/Hash_Map_Manager_T.h"
-
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 # pragma once
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
-#include "ace/Reactor.h"
-#include "ace/Thread_Manager.h"
 #include "ace/Connection_Recycling_Strategy.h"
-#include "ace/Refcountable_T.h"
+#include "ace/Hash_Map_Manager_T.h"
 #include "ace/Hashable.h"
+#include "ace/Reactor.h"
+#include "ace/Refcountable_T.h"
 #include "ace/Recyclable.h"
 #include "ace/Reverse_Lock_T.h"
 
@@ -33,6 +31,7 @@
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
 class ACE_Service_Repository;
+class ACE_Thread_Manager;
 
 /**
  * @class ACE_Recycling_Strategy

--- a/ACE/ace/Strategies_T.inl
+++ b/ACE/ace/Strategies_T.inl
@@ -165,19 +165,6 @@ ACE_Schedule_All_Reactive_Strategy<SVC_HANDLER>::ACE_Schedule_All_Reactive_Strat
     this->reactor_ = scheduler->reactor ();
 }
 
-template <class SVC_HANDLER> ACE_INLINE
-ACE_Schedule_All_Threaded_Strategy<SVC_HANDLER>::ACE_Schedule_All_Threaded_Strategy
-  (SVC_HANDLER *scheduler)
-  : ACE_Scheduling_Strategy<SVC_HANDLER> (scheduler)
-{
-  ACE_TRACE ("ACE_Schedule_All_Threaded_Strategy<SVC_HANDLER>::ACE_Schedule_All_Threaded_Strategy");
-
-  if (scheduler == 0 || scheduler->thr_mgr () == 0)
-    this->thr_mgr_ = ACE_Thread_Manager::instance ();
-  else
-    this->thr_mgr_ = scheduler->thr_mgr ();
-}
-
 template <class T> ACE_INLINE
 ACE_Refcounted_Hash_Recyclable<T>::ACE_Refcounted_Hash_Recyclable (void)
   : ACE_Refcountable_T<ACE_Null_Mutex> (0),

--- a/ACE/ace/Synch.h
+++ b/ACE/ace/Synch.h
@@ -20,6 +20,10 @@
 # pragma once
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
+// *NOTE*: never never never ever #include this file in a header
+//         --> #include "ace/Synch_Traits.h" instead and #include "ace/Synch.h"
+//             in the .cpp. This prevents multiple implicit template
+//             instantiations (linker errors on MSVC)
 #if !defined (DO_NOT_INCLUDE_SYNCH_H)
 
 /* All the classes have been moved out into their own headers as part of

--- a/ACE/ace/TP_Reactor.cpp
+++ b/ACE/ace/TP_Reactor.cpp
@@ -1,4 +1,6 @@
+#include "ace/Synch.h"
 #include "ace/TP_Reactor.h"
+
 #include "ace/Thread.h"
 #include "ace/Timer_Queue.h"
 #include "ace/Sig_Handler.h"

--- a/ACE/ace/Task.cpp
+++ b/ACE/ace/Task.cpp
@@ -1,4 +1,5 @@
 #include "ace/Task.h"
+
 #include "ace/Module.h"
 
 #if !defined (__ACE_INLINE__)

--- a/ACE/ace/Task.h
+++ b/ACE/ace/Task.h
@@ -13,12 +13,11 @@
 #include /**/ "ace/pre.h"
 
 #include "ace/Service_Object.h"
+#include "ace/Thread_Manager.h"
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 # pragma once
 #endif /* ACE_LACKS_PRAGMA_ONCE */
-
-#include "ace/Thread_Manager.h"
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 

--- a/ACE/ace/Task.inl
+++ b/ACE/ace/Task.inl
@@ -1,4 +1,6 @@
 // -*- C++ -*-
+#include "ace/Thread_Manager.h"
+
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
 // Get the current group id.

--- a/ACE/ace/Task_T.cpp
+++ b/ACE/ace/Task_T.cpp
@@ -8,7 +8,7 @@
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
 #include "ace/Module.h"
-#include "ace/Null_Condition.h"
+#include "ace/Synch.h"
 
 #if !defined (__ACE_INLINE__)
 #include "ace/Task_T.inl"
@@ -45,7 +45,7 @@ ACE_Task<ACE_SYNCH_USE, TIME_POLICY>::dump (void) const
 
 template<ACE_SYNCH_DECL, class TIME_POLICY>
 ACE_Task<ACE_SYNCH_USE, TIME_POLICY>::ACE_Task (ACE_Thread_Manager *thr_man,
-                                   ACE_Message_Queue<ACE_SYNCH_USE, TIME_POLICY> *mq)
+                                                ACE_Message_Queue<ACE_SYNCH_USE, TIME_POLICY> *mq)
   : ACE_Task_Base (thr_man),
     msg_queue_ (0),
     delete_msg_queue_ (false),

--- a/ACE/ace/Task_T.inl
+++ b/ACE/ace/Task_T.inl
@@ -2,8 +2,9 @@
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
 template <ACE_SYNCH_DECL, class TIME_POLICY> ACE_INLINE void
-ACE_Task<ACE_SYNCH_USE, TIME_POLICY>::water_marks (ACE_IO_Cntl_Msg::ACE_IO_Cntl_Cmds cmd,
-                                      size_t wm_size)
+ACE_Task<ACE_SYNCH_USE, TIME_POLICY>::water_marks (
+  ACE_IO_Cntl_Msg::ACE_IO_Cntl_Cmds cmd,
+  size_t wm_size)
 {
   ACE_TRACE ("ACE_Task<ACE_SYNCH_USE, TIME_POLICY>::water_marks");
   if (cmd == ACE_IO_Cntl_Msg::SET_LWM)
@@ -13,28 +14,33 @@ ACE_Task<ACE_SYNCH_USE, TIME_POLICY>::water_marks (ACE_IO_Cntl_Msg::ACE_IO_Cntl_
 }
 
 template <ACE_SYNCH_DECL, class TIME_POLICY> ACE_INLINE int
-ACE_Task<ACE_SYNCH_USE, TIME_POLICY>::getq (ACE_Message_Block *&mb, ACE_Time_Value *tv)
+ACE_Task<ACE_SYNCH_USE, TIME_POLICY>::getq (
+  ACE_Message_Block *&mb, ACE_Time_Value *tv)
 {
   ACE_TRACE ("ACE_Task<ACE_SYNCH_USE, TIME_POLICY>::getq");
   return this->msg_queue_->dequeue_head (mb, tv);
 }
 
 template <ACE_SYNCH_DECL, class TIME_POLICY> ACE_INLINE int
-ACE_Task<ACE_SYNCH_USE, TIME_POLICY>::putq (ACE_Message_Block *mb, ACE_Time_Value *tv)
+ACE_Task<ACE_SYNCH_USE, TIME_POLICY>::putq (
+  ACE_Message_Block *mb, ACE_Time_Value *tv)
 {
   ACE_TRACE ("ACE_Task<ACE_SYNCH_USE, TIME_POLICY>::putq");
   return this->msg_queue_->enqueue_tail (mb, tv);
 }
 
 template <ACE_SYNCH_DECL, class TIME_POLICY> ACE_INLINE int
-ACE_Task<ACE_SYNCH_USE, TIME_POLICY>::ungetq (ACE_Message_Block *mb, ACE_Time_Value *tv)
+ACE_Task<ACE_SYNCH_USE, TIME_POLICY>::ungetq (
+  ACE_Message_Block *mb,
+  ACE_Time_Value *tv)
 {
   ACE_TRACE ("ACE_Task<ACE_SYNCH_USE, TIME_POLICY>::ungetq");
   return this->msg_queue_->enqueue_head (mb, tv);
 }
 
 template <ACE_SYNCH_DECL, class TIME_POLICY> ACE_INLINE int
-ACE_Task<ACE_SYNCH_USE, TIME_POLICY>::flush (u_long f)
+ACE_Task<ACE_SYNCH_USE, TIME_POLICY>::flush (
+  u_long f)
 {
   ACE_TRACE ("ACE_Task<ACE_SYNCH_USE, TIME_POLICY>::flush");
   if (ACE_BIT_ENABLED (f, ACE_Task_Flags::ACE_FLUSHALL))
@@ -44,7 +50,8 @@ ACE_Task<ACE_SYNCH_USE, TIME_POLICY>::flush (u_long f)
 }
 
 template <ACE_SYNCH_DECL, class TIME_POLICY> ACE_INLINE void
-ACE_Task<ACE_SYNCH_USE, TIME_POLICY>::msg_queue (ACE_Message_Queue<ACE_SYNCH_USE, TIME_POLICY> *mq)
+ACE_Task<ACE_SYNCH_USE, TIME_POLICY>::msg_queue (
+  ACE_Message_Queue<ACE_SYNCH_USE, TIME_POLICY> *mq)
 {
   ACE_TRACE ("ACE_Task<ACE_SYNCH_USE, TIME_POLICY>::msg_queue");
   if (this->delete_msg_queue_)
@@ -74,14 +81,17 @@ ACE_Task<ACE_SYNCH_USE, TIME_POLICY>::gettimeofday (void) const
 
 template <ACE_SYNCH_DECL, class TIME_POLICY>
 void
-ACE_Task<ACE_SYNCH_USE, TIME_POLICY>::set_time_policy (TIME_POLICY const & rhs)
+ACE_Task<ACE_SYNCH_USE, TIME_POLICY>::set_time_policy (
+  TIME_POLICY const & rhs)
 {
   if (this->msg_queue_ != 0)
     this->msg_queue_->set_time_policy (rhs);
 }
 
 template <ACE_SYNCH_DECL, class TIME_POLICY> ACE_INLINE int
-ACE_Task<ACE_SYNCH_USE, TIME_POLICY>::reply (ACE_Message_Block *mb, ACE_Time_Value *tv)
+ACE_Task<ACE_SYNCH_USE, TIME_POLICY>::reply (
+  ACE_Message_Block *mb,
+  ACE_Time_Value *tv)
 {
   ACE_TRACE ("ACE_Task<ACE_SYNCH_USE, TIME_POLICY>::reply");
   return this->sibling ()->put_next (mb, tv);
@@ -95,7 +105,8 @@ ACE_Task<ACE_SYNCH_USE, TIME_POLICY>::next (void)
 }
 
 template <ACE_SYNCH_DECL, class TIME_POLICY> ACE_INLINE void
-ACE_Task<ACE_SYNCH_USE, TIME_POLICY>::next (ACE_Task<ACE_SYNCH_USE, TIME_POLICY> *q)
+ACE_Task<ACE_SYNCH_USE, TIME_POLICY>::next (
+  ACE_Task<ACE_SYNCH_USE, TIME_POLICY> *q)
 {
   ACE_TRACE ("ACE_Task<ACE_SYNCH_USE, TIME_POLICY>::next");
   this->next_ = q;
@@ -104,7 +115,9 @@ ACE_Task<ACE_SYNCH_USE, TIME_POLICY>::next (ACE_Task<ACE_SYNCH_USE, TIME_POLICY>
 // Transfer msg to the next ACE_Task.
 
 template <ACE_SYNCH_DECL, class TIME_POLICY> ACE_INLINE int
-ACE_Task<ACE_SYNCH_USE, TIME_POLICY>::put_next (ACE_Message_Block *msg, ACE_Time_Value *tv)
+ACE_Task<ACE_SYNCH_USE, TIME_POLICY>::put_next (
+  ACE_Message_Block *msg,
+  ACE_Time_Value *tv)
 {
   ACE_TRACE ("ACE_Task<ACE_SYNCH_USE, TIME_POLICY>::put_next");
   return this->next_ == 0 ? -1 : this->next_->put (msg, tv);

--- a/ACE/ace/Thread_Adapter.cpp
+++ b/ACE/ace/Thread_Adapter.cpp
@@ -1,9 +1,11 @@
 #include "ace/Thread_Adapter.h"
-#include "ace/Thread_Manager.h"
-#include "ace/Thread_Exit.h"
-#include "ace/Thread_Hook.h"
+
 #include "ace/Object_Manager_Base.h"
 #include "ace/Service_Config.h"
+#include "ace/Synch.h"
+#include "ace/Thread_Exit.h"
+#include "ace/Thread_Hook.h"
+#include "ace/Thread_Manager.h"
 
 #if !defined (ACE_HAS_INLINED_OSCALLS)
 # include "ace/Thread_Adapter.inl"

--- a/ACE/ace/Thread_Control.cpp
+++ b/ACE/ace/Thread_Control.cpp
@@ -1,4 +1,6 @@
 #include "ace/Thread_Control.h"
+
+#include "ace/Synch.h"
 #include "ace/Thread_Manager.h"
 
 #if !defined (ACE_HAS_INLINED_OSCALLS)

--- a/ACE/ace/Thread_Exit.cpp
+++ b/ACE/ace/Thread_Exit.cpp
@@ -1,7 +1,9 @@
 #include "ace/Thread_Exit.h"
-#include "ace/Managed_Object.h"
-#include "ace/Thread_Manager.h"
+
 #include "ace/Guard_T.h"
+#include "ace/Managed_Object.h"
+#include "ace/Synch.h"
+#include "ace/Thread_Manager.h"
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 

--- a/ACE/ace/Thread_Manager.cpp
+++ b/ACE/ace/Thread_Manager.cpp
@@ -1,12 +1,14 @@
-#include "ace/TSS_T.h"
+#include "ace/Synch.h"
 #include "ace/Thread_Manager.h"
-#include "ace/Dynamic.h"
-#include "ace/Object_Manager.h"
-#include "ace/Singleton.h"
+
 #include "ace/Auto_Ptr.h"
+#include "ace/Dynamic.h"
 #include "ace/Guard_T.h"
-#include "ace/Time_Value.h"
+#include "ace/Object_Manager.h"
 #include "ace/OS_NS_sys_time.h"
+#include "ace/Singleton.h"
+#include "ace/Time_Value.h"
+#include "ace/TSS_T.h"
 #include "ace/Truncate.h"
 
 #if !defined (__ACE_INLINE__)
@@ -366,12 +368,12 @@ ACE_Thread_Manager::ACE_Thread_Manager (size_t prealloc,
   : grp_id_ (1),
     automatic_wait_ (1)
 #if defined (ACE_HAS_THREADS)
-    , zero_cond_ (lock_)
+  , zero_cond_ (lock_)
 #endif /* ACE_HAS_THREADS */
-    , thread_desc_freelist_ (ACE_FREE_LIST_WITH_POOL,
-                             prealloc, lwm, hwm, inc)
+  , thread_desc_freelist_ (ACE_FREE_LIST_WITH_POOL,
+                           prealloc, lwm, hwm, inc)
 #if defined (ACE_HAS_THREADS) && defined (ACE_LACKS_PTHREAD_JOIN)
-    , join_cond_ (this->lock_)
+  , join_cond_ (lock_)
 #endif
 {
   ACE_TRACE ("ACE_Thread_Manager::ACE_Thread_Manager");
@@ -385,12 +387,12 @@ ACE_Thread_Manager::ACE_Thread_Manager (const ACE_Condition_Attributes &attribut
   : grp_id_ (1),
     automatic_wait_ (1)
 #if defined (ACE_HAS_THREADS)
-    , zero_cond_ (lock_, attributes)
+  , zero_cond_ (lock_, attributes)
 #endif /* ACE_HAS_THREADS */
-    , thread_desc_freelist_ (ACE_FREE_LIST_WITH_POOL,
-                             prealloc, lwm, hwm, inc)
+  , thread_desc_freelist_ (ACE_FREE_LIST_WITH_POOL,
+                           prealloc, lwm, hwm, inc)
 #if defined (ACE_HAS_THREADS) && defined (ACE_LACKS_PTHREAD_JOIN)
-    , join_cond_ (this->lock_)
+  , join_cond_ (lock_)
 #endif
 {
 #if !defined (ACE_HAS_THREADS)

--- a/ACE/ace/Thread_Manager.cpp
+++ b/ACE/ace/Thread_Manager.cpp
@@ -1889,10 +1889,17 @@ ACE_Thread_Manager::wait_task (ACE_Task_Base *task)
                 return -1;
               }
 # endif
-            ACE_SET_BITS (iter.next ()->thr_state_,
-                          ACE_THR_JOINING);
+            ACE_SET_BITS (iter.next ()->thr_state_, ACE_THR_JOINING);
+            this->thr_to_be_removed_.enqueue_tail (iter.next ());
             copy_table[copy_count++] = *iter.next ();
           }
+      }
+
+    if (!this->thr_to_be_removed_.is_empty ())
+      {
+        ACE_Thread_Descriptor *td = 0;
+        while (this->thr_to_be_removed_.dequeue_head (td) != -1)
+          this->remove_thr (td, 0); // *NOTE*: ACE_OS::thr_join() calls ::CloseHandle()
       }
 
 #if !defined (ACE_HAS_VXTHREADS)

--- a/ACE/ace/Thread_Manager.h
+++ b/ACE/ace/Thread_Manager.h
@@ -20,14 +20,15 @@
 # pragma once
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
-#include "ace/Condition_Thread_Mutex.h"
-#include "ace/Unbounded_Queue.h"
+#include "ace/Basic_Types.h"
+#include "ace/Condition_Attributes.h"
 #include "ace/Containers.h"
 #include "ace/Free_List.h"
-#include "ace/Singleton.h"
 #include "ace/Log_Category.h"
+#include "ace/Singleton.h"
+#include "ace/Synch.h"
 #include "ace/Synch_Traits.h"
-#include "ace/Basic_Types.h"
+#include "ace/Unbounded_Queue.h"
 
 // The following macros control how a Thread Manager manages a pool of
 // Thread_Descriptor.  Currently, the default behavior is not to
@@ -1237,16 +1238,16 @@ protected:
   // = ACE_Thread_Mutex and condition variable for synchronizing termination.
 #if defined (ACE_HAS_THREADS)
   /// Serialize access to the <zero_cond_>.
-  ACE_Thread_Mutex lock_;
+  ACE_SYNCH_MUTEX     lock_;
 
   /// Keep track of when there are no more threads.
-  ACE_Condition_Thread_Mutex zero_cond_;
+  ACE_SYNCH_CONDITION zero_cond_;
 #endif /* ACE_HAS_THREADS */
 
   ACE_Locked_Free_List<ACE_Thread_Descriptor, ACE_SYNCH_MUTEX> thread_desc_freelist_;
 
 #if defined (ACE_HAS_THREADS) && defined (ACE_LACKS_PTHREAD_JOIN)
-  ACE_Condition_Thread_Mutex join_cond_;
+  ACE_SYNCH_CONDITION join_cond_;
 #endif
 
 private:

--- a/ACE/ace/Timer_Hash.h
+++ b/ACE/ace/Timer_Hash.h
@@ -13,61 +13,74 @@
 #define ACE_TIMER_HASH_H
 #include /**/ "ace/pre.h"
 
-#include "ace/Timer_Hash_T.h"
-#include "ace/Event_Handler_Handle_Timeout_Upcall.h"
-
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 # pragma once
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
+#include "ace/Event_Handler_Handle_Timeout_Upcall.h"
+#include "ace/Synch_Traits.h"
 #include "ace/Timer_Heap_T.h"
+#include "ace/Timer_Hash_T.h"
 #include "ace/Timer_List_T.h"
+#include "ace/Timer_Queuefwd.h"
+#include "ace/Timer_Wheel_T.h"
+
+class ACE_Event_Handler;
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
 // The following typedef are here for ease of use
 
-typedef ACE_Timer_Hash_Upcall <ACE_Event_Handler *,
-                               ACE_Event_Handler_Handle_Timeout_Upcall,
-                               ACE_SYNCH_RECURSIVE_MUTEX>
+typedef ACE_Timer_Hash_Upcall <ACE_Timer_Queue,
+                               ACE_Event_Handler,
+                               ACE_Event_Handler_Handle_Timeout_Upcall>
         ACE_Hash_Upcall;
 
-typedef ACE_Timer_List_T <ACE_Event_Handler *,
+typedef ACE_Timer_List_T <ACE_Event_Handler,
                           ACE_Hash_Upcall,
-                          ACE_Null_Mutex>
+                          ACE_SYNCH_NULL_MUTEX,
+                          ACE_Default_Time_Policy>
         ACE_Hash_Timer_List;
 
-typedef ACE_Timer_Heap_T <ACE_Event_Handler *,
+typedef ACE_Timer_Heap_T <ACE_Event_Handler,
                           ACE_Hash_Upcall,
-                          ACE_Null_Mutex>
+                          ACE_SYNCH_NULL_MUTEX,
+                          ACE_Default_Time_Policy>
         ACE_Hash_Timer_Heap;
 
+typedef ACE_Timer_Wheel_T <ACE_Event_Handler,
+                           ACE_Hash_Upcall,
+                           ACE_SYNCH_NULL_MUTEX,
+                           ACE_Default_Time_Policy>
+        ACE_Hash_Timer_Wheel;
 
-typedef ACE_Timer_Hash_T<ACE_Event_Handler *,
-                        ACE_Event_Handler_Handle_Timeout_Upcall,
-                        ACE_SYNCH_RECURSIVE_MUTEX,
-                        ACE_Hash_Timer_List>
+typedef ACE_Timer_Hash_T<ACE_Event_Handler,
+                         ACE_Event_Handler_Handle_Timeout_Upcall,
+                         ACE_SYNCH_RECURSIVE_MUTEX,
+                         ACE_Hash_Timer_List>
+        ACE_Timer_Hash_List;
 
-        ACE_Timer_Hash;
+typedef ACE_Timer_Hash_List::ITERATOR_T ACE_Timer_Hash_List_Iterator;
 
-typedef ACE_Timer_Hash_Iterator_T<ACE_Event_Handler *,
-                                  ACE_Event_Handler_Handle_Timeout_Upcall,
-                                  ACE_SYNCH_RECURSIVE_MUTEX,
-                                  ACE_Hash_Timer_List,
-                                  ACE_Default_Time_Policy>
-        ACE_Timer_Hash_Iterator;
-
-typedef ACE_Timer_Hash_T<ACE_Event_Handler *,
-                        ACE_Event_Handler_Handle_Timeout_Upcall,
-                        ACE_SYNCH_RECURSIVE_MUTEX,
-                        ACE_Hash_Timer_Heap>
+typedef ACE_Timer_Hash_T<ACE_Event_Handler,
+                         ACE_Event_Handler_Handle_Timeout_Upcall,
+                         ACE_SYNCH_RECURSIVE_MUTEX,
+                         ACE_Hash_Timer_Heap,
+                         ACE_Default_Time_Policy>
         ACE_Timer_Hash_Heap;
 
-typedef ACE_Timer_Hash_Iterator_T<ACE_Event_Handler *,
-                                  ACE_Event_Handler_Handle_Timeout_Upcall,
-                                  ACE_SYNCH_RECURSIVE_MUTEX,
-                                  ACE_Hash_Timer_Heap>
-        ACE_Timer_Hash_Heap_Iterator;
+typedef ACE_Timer_Hash_Heap::ITERATOR_T ACE_Timer_Hash_Heap_Iterator;
+
+typedef ACE_Timer_Hash_T<ACE_Event_Handler,
+                         ACE_Event_Handler_Handle_Timeout_Upcall,
+                         ACE_SYNCH_RECURSIVE_MUTEX,
+                         ACE_Hash_Timer_Wheel,
+                         ACE_Default_Time_Policy>
+        ACE_Timer_Hash_Wheel;
+
+typedef ACE_Timer_Hash_Wheel::ITERATOR_T ACE_Timer_Hash_Wheel_Iterator;
+
+typedef ACE_Timer_Hash_Heap ACE_Timer_Hash;
 
 ACE_END_VERSIONED_NAMESPACE_DECL
 

--- a/ACE/ace/Timer_Hash_T.cpp
+++ b/ACE/ace/Timer_Hash_T.cpp
@@ -7,9 +7,10 @@
 # pragma once
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
-#include "ace/OS_NS_sys_time.h"
 #include "ace/Guard_T.h"
 #include "ace/Log_Category.h"
+#include "ace/OS_NS_sys_time.h"
+#include "ace/Synch.h"
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -39,7 +40,7 @@ public:
   void set (const void *act,
             size_t pos,
             long orig_id,
-            const TYPE &type)
+            const TYPE *type)
   {
     this->act_ = act;
     this->pos_ = pos;
@@ -51,125 +52,178 @@ public:
   const void *act_;
   size_t pos_;
   long orig_id_;
-  TYPE type_;
+  const TYPE* type_;
   /// Pointer to next token.
   Hash_Token<TYPE> *next_;
 };
 
 // Default constructor
 
-template <class TYPE, class FUNCTOR, class ACE_LOCK>
-ACE_Timer_Hash_Upcall<TYPE, FUNCTOR, ACE_LOCK>::ACE_Timer_Hash_Upcall (void)
+template <class TQ_TYPE, class TYPE, class FUNCTOR>
+ACE_Timer_Hash_Upcall<TQ_TYPE, TYPE, FUNCTOR>::ACE_Timer_Hash_Upcall (void)
   : timer_hash_ (0)
+  , upcall_functor_ (0)
+  , delete_upcall_functor_ (false)
 {
   // Nothing
 }
 
 // Constructor that specifies a Timer_Hash to call up to
 
-template <class TYPE, class FUNCTOR, class ACE_LOCK>
-ACE_Timer_Hash_Upcall<TYPE, FUNCTOR, ACE_LOCK>::ACE_Timer_Hash_Upcall (
-  ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK> *timer_hash)
+template <class TQ_TYPE, class TYPE, class FUNCTOR>
+ACE_Timer_Hash_Upcall<TQ_TYPE, TYPE, FUNCTOR>::ACE_Timer_Hash_Upcall (
+  TQ_TYPE *timer_hash,
+  FUNCTOR *upcall_functor)
   : timer_hash_ (timer_hash)
+  , upcall_functor_ (upcall_functor)
+  , delete_upcall_functor_ (false)
 {
   // Nothing
 }
 
-template <class TYPE, class FUNCTOR, class ACE_LOCK> int
-ACE_Timer_Hash_Upcall<TYPE, FUNCTOR, ACE_LOCK>::registration (
-  TIMER_QUEUE &,
-  ACE_Event_Handler *,
-  const void *)
+template <class TQ_TYPE, class TYPE, class FUNCTOR> void
+ACE_Timer_Hash_Upcall<TQ_TYPE, TYPE, FUNCTOR>::upcall_functor (FUNCTOR *upcall_functor,
+                                                               bool delete_upcall_functor)
 {
-  // Registration will be handled by the upcall functor of the timer
-  // hash.
-  return 0;
+  if (delete_upcall_functor_)
+    delete upcall_functor_;
+
+  upcall_functor_ = upcall_functor;
+  delete_upcall_functor_ = (upcall_functor && delete_upcall_functor);
 }
 
-template <class TYPE, class FUNCTOR, class ACE_LOCK> int
-ACE_Timer_Hash_Upcall<TYPE, FUNCTOR, ACE_LOCK>::preinvoke (TIMER_QUEUE &,
-                                                           ACE_Event_Handler *,
-                                                           const void *,
-                                                           int,
-                                                           const ACE_Time_Value &,
-                                                           const void *&)
+template <class TQ_TYPE, class TYPE, class FUNCTOR> int
+ACE_Timer_Hash_Upcall<TQ_TYPE, TYPE, FUNCTOR>::registration (
+  TQ_TYPE &,
+  TYPE *handler,
+  const void *act)
 {
-  // This method should never be invoked since we don't invoke
-  // expire() on the buckets.
-  ACE_ASSERT (0);
-  return 0;
+  int result = -1;
+
+  if (upcall_functor_)
+    result = this->upcall_functor_->registration (*this->timer_hash_,
+                                                  handler,
+                                                  act);
+
+  return result;
 }
 
-template <class TYPE, class FUNCTOR, class ACE_LOCK> int
-ACE_Timer_Hash_Upcall<TYPE, FUNCTOR, ACE_LOCK>::postinvoke (
-  TIMER_QUEUE &,
-  ACE_Event_Handler *,
-  const void *,
-  int,
-  const ACE_Time_Value &,
-  const void *)
+template <class TQ_TYPE, class TYPE, class FUNCTOR> int
+ACE_Timer_Hash_Upcall<TQ_TYPE, TYPE, FUNCTOR>::preinvoke (
+  TQ_TYPE &,
+  TYPE *handler,
+  const void *arg,
+  int recurring_timer,
+  const ACE_Time_Value &cur_time,
+  const void *act)
 {
-  // This method should never be invoked since we don't invoke
-  // expire() on the buckets.
-  ACE_ASSERT (0);
-  return 0;
+  int result = -1;
+
+  if (upcall_functor_)
+    result = this->upcall_functor_->preinvoke (*this->timer_hash_,
+                                               handler,
+                                               arg,
+                                               recurring_timer,
+                                               cur_time,
+                                               act);
+
+  return result;
+}
+
+template <class TQ_TYPE, class TYPE, class FUNCTOR> int
+ACE_Timer_Hash_Upcall<TQ_TYPE, TYPE, FUNCTOR>::postinvoke (
+  TQ_TYPE &,
+  TYPE *handler,
+  const void *arg,
+  int recurring_timer,
+  const ACE_Time_Value &cur_time,
+  const void *act)
+{
+  int result = -1;
+
+  if (upcall_functor_)
+    result = this->upcall_functor_->postinvoke (*this->timer_hash_,
+                                                handler,
+                                                arg,
+                                                recurring_timer,
+                                                cur_time,
+                                                act);
+
+  return result;
 }
 
 // Calls up to timer_hash's upcall functor
-template <class TYPE, class FUNCTOR, class ACE_LOCK> int
-ACE_Timer_Hash_Upcall<TYPE, FUNCTOR, ACE_LOCK>::timeout (
-  TIMER_QUEUE &,
-  ACE_Event_Handler *,
-  const void *,
-  int,
-  const ACE_Time_Value &)
+template <class TQ_TYPE, class TYPE, class FUNCTOR> int
+ACE_Timer_Hash_Upcall<TQ_TYPE, TYPE, FUNCTOR>::timeout (
+  TQ_TYPE &,
+  TYPE *handler,
+  const void *arg,
+  int dont_call,
+  const ACE_Time_Value &cur_time)
 {
-  // This method should never be invoked since we don't invoke
-  // expire() on the buckets.
-  ACE_ASSERT (0);
-  return 0;
+  int result = -1;
+
+  if (upcall_functor_)
+    result = this->upcall_functor_->timeout (*this->timer_hash_,
+                                             handler,
+                                             arg,
+                                             dont_call,
+                                             cur_time);
+
+  return result;
 }
 
-template <class TYPE, class FUNCTOR, class ACE_LOCK> int
-ACE_Timer_Hash_Upcall<TYPE, FUNCTOR, ACE_LOCK>::cancel_type (
-  TIMER_QUEUE &,
-  ACE_Event_Handler *,
-  int,
-  int &)
+template <class TQ_TYPE, class TYPE, class FUNCTOR> int
+ACE_Timer_Hash_Upcall<TQ_TYPE, TYPE, FUNCTOR>::cancel_type (
+  TQ_TYPE &,
+  TYPE *handler,
+  int dont_call,
+  int &requires_reference_counting)
 {
-  // Cancellation will be handled by the upcall functor of the timer
-  // hash.
-  return 0;
+  int result = -1;
+
+  if (upcall_functor_)
+    result = this->upcall_functor_->cancel_type (*this->timer_hash_,
+                                                 handler,
+                                                 dont_call,
+                                                 requires_reference_counting);
+
+  return result;
 }
 
-template <class TYPE, class FUNCTOR, class ACE_LOCK> int
-ACE_Timer_Hash_Upcall<TYPE, FUNCTOR, ACE_LOCK>::cancel_timer (
-  TIMER_QUEUE &,
-  ACE_Event_Handler *,
-  int,
-  int)
+template <class TQ_TYPE, class TYPE, class FUNCTOR> int
+ACE_Timer_Hash_Upcall<TQ_TYPE, TYPE, FUNCTOR>::cancel_timer (
+  TQ_TYPE &,
+  TYPE *handler,
+  int dont_call,
+  int requires_reference_counting)
 {
-  // Cancellation will be handled by the upcall functor of the timer
-  // hash.
-  return 0;
+  int result = -1;
+
+  if (upcall_functor_)
+    result = this->upcall_functor_->cancel_timer (*this->timer_hash_,
+                                                  handler,
+                                                  dont_call,
+                                                  requires_reference_counting);
+
+  return result;
 }
 
-template <class TYPE, class FUNCTOR, class ACE_LOCK> int
-ACE_Timer_Hash_Upcall<TYPE, FUNCTOR, ACE_LOCK>::deletion (
-  TIMER_QUEUE &,
-  ACE_Event_Handler *event_handler,
+template <class TQ_TYPE, class TYPE, class FUNCTOR> int
+ACE_Timer_Hash_Upcall<TQ_TYPE, TYPE, FUNCTOR>::deletion (
+  TQ_TYPE &,
+  TYPE *handler,
   const void *arg)
 {
-  // Call up to the upcall functor of the timer hash since the timer
-  // hash does not invoke deletion() on its upcall functor directly.
   Hash_Token<TYPE> *h =
     reinterpret_cast<Hash_Token<TYPE> *> (const_cast<void *> (arg));
 
-  int result =
-    this->timer_hash_->upcall_functor ().
-    deletion (*this->timer_hash_,
-              event_handler,
-              h->act_);
+  int result = -1;
+
+  if (upcall_functor_)
+    result = this->upcall_functor_->deletion (*this->timer_hash_,
+                                              handler,
+                                              h->act_);
 
   return result;
 }
@@ -252,8 +306,7 @@ ACE_Timer_Hash_Iterator_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::isdone 
 
 // Returns the node at the current position in the sequence
 
-template <class TYPE, class FUNCTOR, class ACE_LOCK, class BUCKET, typename TIME_POLICY>
-ACE_Timer_Node_T<TYPE> *
+template <class TYPE, class FUNCTOR, class ACE_LOCK, class BUCKET, typename TIME_POLICY> ACE_Timer_Node_T<TYPE> *
 ACE_Timer_Hash_Iterator_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::item (void)
 {
   if (this->isdone ())
@@ -262,8 +315,7 @@ ACE_Timer_Hash_Iterator_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::item (v
   return this->iter_->item ();
 }
 
-template <class TYPE, class FUNCTOR, class ACE_LOCK, class BUCKET, typename TIME_POLICY>
-ACE_Timer_Queue_Iterator_T<TYPE> &
+template <class TYPE, class FUNCTOR, class ACE_LOCK, class BUCKET, typename TIME_POLICY> ACE_Timer_Queue_Iterator_T<TYPE> &
 ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::iter (void)
 {
   this->iterator_->first ();
@@ -277,11 +329,11 @@ ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::ACE_Timer_Hash_T
   size_t table_size,
   FUNCTOR *upcall_functor,
   ACE_Free_List<ACE_Timer_Node_T <TYPE> > *freelist,
-  TIME_POLICY const & time_policy)
-  : Base_Timer_Queue (upcall_functor, freelist, time_policy),
+  TIME_POLICY const &time_policy)
+  : inherited (upcall_functor, freelist, time_policy),
     size_ (0),
     table_size_ (table_size),
-    table_functor_ (this),
+    table_functor_ (this, upcall_functor),
     earliest_position_ (0),
     iterator_ (0)
 #if defined (ACE_WIN64)
@@ -300,24 +352,32 @@ ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::ACE_Timer_Hash_T
     {
       ACE_NEW (this->table_[i],
                BUCKET (&this->table_functor_,
-                      this->free_list_,
-                      time_policy));
+                       this->free_list_,
+                       time_policy));
+    }
+
+  if (!upcall_functor)
+    {
+      FUNCTOR* functor = 0;
+      ACE_NEW (functor,
+               FUNCTOR ());
+
+      this->table_functor_.upcall_functor (functor, true);
     }
 
   ACE_NEW (iterator_,
-           HASH_ITERATOR (*this));
+           ITERATOR_T (*this));
 }
-
 
 template <class TYPE, class FUNCTOR, class ACE_LOCK, class BUCKET, typename TIME_POLICY>
 ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::ACE_Timer_Hash_T (
   FUNCTOR *upcall_functor,
   ACE_Free_List<ACE_Timer_Node_T <TYPE> > *freelist,
-  TIME_POLICY const & time_policy)
-  : Base_Timer_Queue (upcall_functor, freelist, time_policy),
+  TIME_POLICY const &time_policy)
+  : inherited (upcall_functor, freelist, time_policy),
     size_ (0),
     table_size_ (ACE_DEFAULT_TIMER_HASH_TABLE_SIZE),
-    table_functor_ (this),
+    table_functor_ (this, upcall_functor),
     earliest_position_ (0)
 #if defined (ACE_WIN64)
   , pointer_base_ (0)
@@ -335,12 +395,21 @@ ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::ACE_Timer_Hash_T
     {
       ACE_NEW (this->table_[i],
                BUCKET (&this->table_functor_,
-                      this->free_list_,
-                      time_policy));
+                       this->free_list_,
+                       time_policy));
+    }
+
+    if (!upcall_functor)
+    {
+      FUNCTOR* functor = 0;
+      ACE_NEW (functor,
+               FUNCTOR ());
+
+      this->table_functor_.upcall_functor (functor, true);
     }
 
   ACE_NEW (iterator_,
-           HASH_ITERATOR (*this));
+           ITERATOR_T (*this));
 }
 
 // Remove all remaining items in the Queue.
@@ -349,7 +418,7 @@ template <class TYPE, class FUNCTOR, class ACE_LOCK, class BUCKET, typename TIME
 ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::~ACE_Timer_Hash_T (void)
 {
   ACE_TRACE ("ACE_Timer_Hash_T::~ACE_Timer_Hash_T");
-  ACE_MT (ACE_GUARD (ACE_LOCK, ace_mon, this->mutex_));
+  //ACE_MT (ACE_GUARD (ACE_LOCK, ace_mon, this->mutex_));
 
   delete iterator_;
 
@@ -368,15 +437,15 @@ template <class TYPE, class FUNCTOR, class ACE_LOCK, class BUCKET, typename TIME
 ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::close (void)
 {
   ACE_TRACE ("ACE_Timer_Hash_T::close");
-  ACE_MT (ACE_GUARD_RETURN (ACE_LOCK, ace_mon, this->mutex_, -1));
+  //ACE_MT (ACE_GUARD_RETURN (ACE_LOCK, ace_mon, this->mutex_, -1));
 
   // Remove all remaining items from the queue.
-  while (!this->is_empty())
+  while (!this->is_empty ())
     {
-      ACE_Timer_Node_T<TYPE>* n = this->remove_first();
+      ACE_Timer_Node_T<TYPE>* n = this->remove_first ();
       this->upcall_functor ().deletion (*this,
-                                        n->get_type(),
-                                        n->get_act());
+                                        n->get_type (),
+                                        n->get_act ());
       this->free_node (n);
     }
 
@@ -390,17 +459,22 @@ template <class TYPE, class FUNCTOR, class ACE_LOCK, class BUCKET, typename TIME
 ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::is_empty (void) const
 {
   ACE_TRACE ("ACE_Timer_Hash_T::is_empty");
-  return this->table_[this->earliest_position_]->is_empty ();
+
+  BUCKET* bucket = this->table_[this->earliest_position_];
+  ACE_ASSERT (bucket);
+  return bucket->is_empty ();
 }
 
 // Returns earliest time in a non-empty bucket
 
-template <class TYPE, class FUNCTOR, class ACE_LOCK, class BUCKET, typename TIME_POLICY>
-const ACE_Time_Value &
+template <class TYPE, class FUNCTOR, class ACE_LOCK, class BUCKET, typename TIME_POLICY> const ACE_Time_Value &
 ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::earliest_time (void) const
 {
   ACE_TRACE ("ACE_Timer_Hash_T::earliest_time");
-  return this->table_[this->earliest_position_]->earliest_time ();
+
+  BUCKET* bucket = this->table_[this->earliest_position_];
+  ACE_ASSERT (bucket);
+  return bucket->earliest_time ();
 }
 
 template <class TYPE, class FUNCTOR, class ACE_LOCK, class BUCKET, typename TIME_POLICY> void
@@ -424,8 +498,7 @@ ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::dump (void) cons
 // Reschedule a periodic timer.  This function must be called with the
 // mutex lock held.
 
-template <class TYPE, class FUNCTOR, class ACE_LOCK, class BUCKET, typename TIME_POLICY>
-void
+template <class TYPE, class FUNCTOR, class ACE_LOCK, class BUCKET, typename TIME_POLICY> void
 ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::reschedule (
   ACE_Timer_Node_T<TYPE> *expired)
 {
@@ -434,6 +507,7 @@ ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::reschedule (
   Hash_Token<TYPE> *h =
     reinterpret_cast<Hash_Token<TYPE> *> (
       const_cast<void *> (expired->get_act ()));
+  ACE_ASSERT (h);
 
   // Don't use ACE_Utils::truncate_cast<> here.  A straight
   // static_cast<>  will provide more unique results when the number
@@ -453,7 +527,7 @@ ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::reschedule (
   // then here schedule <expired> for deletion. Don't call
   // this->free_node() because that will invalidate <h>
   // and that's what user have as timer_id.
-  Base_Timer_Queue::free_node (expired);
+  inherited::free_node (expired);
 
   if (this->table_[this->earliest_position_]->is_empty ()
       || this->table_[h->pos_]->earliest_time ()
@@ -464,10 +538,9 @@ ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::reschedule (
 // Insert a new handler that expires at time future_time; if interval
 // is > 0, the handler will be reinvoked periodically.
 
-template <class TYPE, class FUNCTOR, class ACE_LOCK, class BUCKET, typename TIME_POLICY>
-long
+template <class TYPE, class FUNCTOR, class ACE_LOCK, class BUCKET, typename TIME_POLICY> long
 ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::schedule_i (
-  const TYPE &type,
+  TYPE *handler,
   const void *act,
   const ACE_Time_Value &future_time,
   const ACE_Time_Value &interval)
@@ -483,10 +556,11 @@ ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::schedule_i (
   // Don't create Hash_Token directly. Instead we get one from Free_List
   // and then set it properly.
   Hash_Token<TYPE> *h = this->token_list_.remove ();
-  h->set (act, position, 0, type);
+  ACE_ASSERT (h);
+  h->set (act, position, 0, handler);
 
   h->orig_id_ =
-    this->table_[position]->schedule (type,
+    this->table_[position]->schedule (handler,
                                       h,
                                       future_time,
                                       interval);
@@ -519,11 +593,10 @@ ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::schedule_i (
 
 // Locate and update the inteval on the timer_id
 
-template <class TYPE, class FUNCTOR, class ACE_LOCK, class BUCKET, typename TIME_POLICY>
-int
+template <class TYPE, class FUNCTOR, class ACE_LOCK, class BUCKET, typename TIME_POLICY> int
 ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::reset_interval (
   long timer_id,
-  const ACE_Time_Value & interval)
+  const ACE_Time_Value &interval)
 {
   ACE_TRACE ("ACE_Timer_Hash_T::reset_interval");
 
@@ -532,22 +605,18 @@ ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::reset_interval (
   if (timer_id == -1)
     return -1;
 
+  ACE_MT (ACE_GUARD_RETURN (ACE_LOCK, ace_mon, this->mutex_, -1));
 #if defined (ACE_WIN64)
   unsigned long const timer_offset =
     static_cast<unsigned long> (timer_id);
-
-  ACE_MT (ACE_GUARD_RETURN (ACE_LOCK, ace_mon, this->mutex_, -1));
 
   Hash_Token<TYPE> * const h =
     reinterpret_cast<Hash_Token<TYPE> *> (this->pointer_base_ + timer_offset);
 #else
   Hash_Token<TYPE> * const h =
     reinterpret_cast<Hash_Token<TYPE> *> (timer_id);
-
-  // Grab the lock before accessing the table.  We don't need to do so
-  // before this point since no members are accessed until now.
-  ACE_MT (ACE_GUARD_RETURN (ACE_LOCK, ace_mon, this->mutex_, -1));
 #endif /* ACE_WIN64 */
+  ACE_ASSERT (h);
 
   return this->table_[h->pos_]->reset_interval (h->orig_id_,
                                                 interval);
@@ -556,11 +625,11 @@ ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::reset_interval (
 // Locate and remove the single <ACE_Event_Handler> with a value of
 // @a timer_id from the correct table timer queue.
 
-template <class TYPE, class FUNCTOR, class ACE_LOCK, class BUCKET, typename TIME_POLICY>
-int
-ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::cancel (long timer_id,
-                                                           const void **act,
-                                                           int dont_call)
+template <class TYPE, class FUNCTOR, class ACE_LOCK, class BUCKET, typename TIME_POLICY> int
+ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::cancel (
+  long timer_id,
+  const void **act,
+  int dont_call)
 {
   ACE_TRACE ("ACE_Timer_Hash_T::cancel");
 
@@ -569,44 +638,26 @@ ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::cancel (long tim
   if (timer_id == -1)
     return 0;
 
+  ACE_MT (ACE_GUARD_RETURN (ACE_LOCK, ace_mon, this->mutex_, -1));
 #if defined (ACE_WIN64)
   unsigned long const timer_offset =
     static_cast<unsigned long> (timer_id);
-
-  ACE_MT (ACE_GUARD_RETURN (ACE_LOCK, ace_mon, this->mutex_, -1));
 
   Hash_Token<TYPE> * const h =
     reinterpret_cast<Hash_Token<TYPE> *> (this->pointer_base_ + timer_offset);
 #else
   Hash_Token<TYPE> * const h =
     reinterpret_cast<Hash_Token<TYPE> *> (timer_id);
-
-  // Grab the lock before accessing the table.  We don't need to do so
-  // before this point since no members are accessed until now.
-  ACE_MT (ACE_GUARD_RETURN (ACE_LOCK, ace_mon, this->mutex_, -1));
 #endif /* ACE_WIN64 */
+  ACE_ASSERT (h);
 
+  // Note: close hooks to be called by the bucket
   int const result = this->table_[h->pos_]->cancel (h->orig_id_,
                                                     0,
                                                     dont_call);
 
   if (result == 1)
     {
-      // Call the close hooks.
-      int cookie = 0;
-
-      // cancel_type() called once per <type>.
-      this->upcall_functor ().cancel_type (*this,
-                                           h->type_,
-                                           dont_call,
-                                           cookie);
-
-      // cancel_timer() called once per <timer>.
-      this->upcall_functor ().cancel_timer (*this,
-                                            h->type_,
-                                            dont_call,
-                                            cookie);
-
       if (h->pos_ == this->earliest_position_)
         this->find_new_earliest ();
 
@@ -626,14 +677,15 @@ ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::cancel (long tim
 
 // Locate and remove all values of <type> from the timer queue.
 
-template <class TYPE, class FUNCTOR, class ACE_LOCK, class BUCKET, typename TIME_POLICY>
-int
-ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::cancel (const TYPE &type,
-                                                           int dont_call)
+template <class TYPE, class FUNCTOR, class ACE_LOCK, class BUCKET, typename TIME_POLICY> int
+ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::cancel (
+  TYPE *handler,
+  int dont_call)
 {
   ACE_TRACE ("ACE_Timer_Hash_T::cancel");
 
   size_t i; // loop variable.
+  int result = 0;
 
   Hash_Token<TYPE> **timer_ids = 0;
   size_t pos = 0;
@@ -644,34 +696,50 @@ ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::cancel (const TY
                   Hash_Token<TYPE> *[this->size_],
                   -1);
 
+  int dont_call_handle_close = dont_call;
+  bool has_type = false;
+  int result_temp = 0;
   for (i = 0;
        i < this->table_size_;
        ++i)
     {
+      has_type = false;
+
       ACE_Timer_Queue_Iterator_T<TYPE> & iter =
         this->table_[i]->iter ();
 
       for (iter.first ();
            !iter.isdone ();
            iter.next ())
-        if (iter.item ()->get_type () == type)
-          timer_ids[pos++] =
-            reinterpret_cast<Hash_Token<TYPE> *> (
-              const_cast<void *> (iter.item ()->get_act ()));
+        if (iter.item ()->get_type () == handler)
+          {
+            has_type = true;
+
+            timer_ids[pos] =
+              reinterpret_cast<Hash_Token<TYPE> *> (
+                const_cast<void *> (iter.item ()->get_act ()));
+            ACE_ASSERT (timer_ids[pos]);
+
+            ++pos;
+          }
     }
+    if (has_type)
+      {
+        result_temp = this->table_[i]->cancel (handler,
+                                               dont_call_handle_close);
+        if (result_temp == -1)
+          result = -1;
+        else
+          result += result_temp;
+        if (dont_call_handle_close == 0)
+          dont_call_handle_close = 1; // call once per type only (iff at all)
+      }
 
   if (pos > this->size_)
     return -1;
 
   for (i = 0; i < pos; ++i)
     {
-      int const result =
-        this->table_[timer_ids[i]->pos_]->cancel (timer_ids[i]->orig_id_,
-                                                  0,
-                                                  dont_call);
-      ACE_ASSERT (result == 1);
-      ACE_UNUSED_ARG (result);
-
       // We could destruct Hash_Token explicitly but we better
       // schedule it for destruction.
       this->token_list_.add (timer_ids[i]);
@@ -683,25 +751,20 @@ ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::cancel (const TY
 
   this->find_new_earliest ();
 
+  // Note: close hooks to be called by the bucket(s)
+  // iff there were no timers to cancel, invoke cancel_type() once anyway
+  // (otherwise it would have been called from the bucket(s), once per bucket
+  // [note that this behaviour is inconsistent, but unavoidable at this stage])
+
   // Call the close hooks.
   int cookie = 0;
 
   // cancel_type() called once per <type>.
-  this->upcall_functor ().cancel_type (*this,
-                                       type,
-                                       dont_call,
-                                       cookie);
-
-  for (i = 0;
-       i < pos;
-       ++i)
-    {
-      // cancel_timer() called once per <timer>.
-      this->upcall_functor ().cancel_timer (*this,
-                                            type,
-                                            dont_call,
-                                            cookie);
-    }
+  if (result <= 0)
+    this->upcall_functor ().cancel_type (*this,
+                                         handler,
+                                         dont_call,
+                                         cookie);
 
   return static_cast<int> (pos);
 }
@@ -714,8 +777,9 @@ ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::remove_first (vo
   if (this->is_empty ())
     return 0;
 
-  ACE_Timer_Node_T<TYPE> *temp =
-    this->table_[this->earliest_position_]->remove_first ();
+  BUCKET* bucket = this->table_[this->earliest_position_];
+  ACE_ASSERT (bucket);
+  ACE_Timer_Node_T<TYPE> *temp = bucket->remove_first ();
 
   this->find_new_earliest ();
 
@@ -747,17 +811,20 @@ ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::get_first (void)
   if (this->is_empty ())
     return 0;
 
-  return this->table_[this->earliest_position_]->get_first ();
+  BUCKET* bucket = this->table_[this->earliest_position_];
+  ACE_ASSERT (bucket);
+  return bucket->get_first ();
 }
 
 template <class TYPE, class FUNCTOR, class ACE_LOCK, class BUCKET, typename TIME_POLICY> void
 ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::free_node (ACE_Timer_Node_T<TYPE> *node)
 {
-  Base_Timer_Queue::free_node (node);
-
   Hash_Token<TYPE> *h =
     reinterpret_cast<Hash_Token<TYPE> *> (const_cast<void *> (node->get_act ()));
+  ACE_ASSERT (h);
   this->token_list_.add (h);
+
+  inherited::free_node (node);
 }
 
 template <class TYPE, class FUNCTOR, class ACE_LOCK, class BUCKET, typename TIME_POLICY> int
@@ -765,12 +832,13 @@ ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::dispatch_info_i 
                                                                     ACE_Timer_Node_Dispatch_Info_T<TYPE> &info)
 {
   int const result =
-    Base_Timer_Queue::dispatch_info_i (cur_time, info);
+    inherited::dispatch_info_i (cur_time, info);
 
   if (result == 1)
     {
       Hash_Token<TYPE> *h =
         reinterpret_cast<Hash_Token<TYPE> *> (const_cast<void *> (info.act_));
+      ACE_ASSERT (h);
 
       info.act_ = h->act_;
     }
@@ -783,7 +851,7 @@ ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::dispatch_info_i 
 template <class TYPE, class FUNCTOR, class ACE_LOCK, class BUCKET, typename TIME_POLICY> int
 ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::expire ()
 {
-  return Base_Timer_Queue::expire();
+  return inherited::expire ();
 }
 
 // Specialized expire for Timer Hash
@@ -796,11 +864,15 @@ ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::expire (const AC
   int number_of_timers_expired = 0;
 
   ACE_Timer_Node_T<TYPE> *expired = 0;
+  Hash_Token<TYPE> *h = 0;
+  ACE_Timer_Node_Dispatch_Info_T<TYPE> info;
+  const void *upcall_act = 0;
 
   ACE_MT (ACE_GUARD_RETURN (ACE_LOCK, ace_mon, this->mutex_, -1));
 
   // Go through the table and expire anything that can be expired
 
+  bool reclaim = true;
   for (size_t i = 0;
        i < this->table_size_;
        ++i)
@@ -809,13 +881,19 @@ ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::expire (const AC
              && this->table_[i]->earliest_time () <= cur_time)
         {
           expired = this->table_[i]->remove_first ();
-          const void *act = expired->get_act ();
-          bool reclaim = true;
+          ACE_ASSERT (expired);
+          h = 0;
+          upcall_act = 0;
+          reclaim = true;
 
-          Hash_Token<TYPE> *h =
-            reinterpret_cast<Hash_Token<TYPE> *> (const_cast<void *> (act));
+          // Get the dispatch info
+          expired->get_dispatch_info (info);
 
-          ACE_ASSERT (h->pos_ == i);
+          h =
+            reinterpret_cast<Hash_Token<TYPE> *> (const_cast<void *> (expired->get_act ()));
+          ACE_ASSERT (h && (h->pos_ == i));
+          
+          info.act_ = h->act_;
 
           // Check if this is an interval timer.
           if (expired->get_interval () > ACE_Time_Value::zero)
@@ -834,15 +912,6 @@ ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::expire (const AC
               this->free_node (expired);
             }
 
-          ACE_Timer_Node_Dispatch_Info_T<TYPE> info;
-
-          // Get the dispatch info
-          expired->get_dispatch_info (info);
-
-          info.act_ = h->act_;
-
-          const void *upcall_act = 0;
-
           this->preinvoke (info, cur_time, upcall_act);
 
           this->upcall (info, cur_time);
@@ -850,12 +919,10 @@ ACE_Timer_Hash_T<TYPE, FUNCTOR, ACE_LOCK, BUCKET, TIME_POLICY>::expire (const AC
           this->postinvoke (info, cur_time, upcall_act);
 
           if (reclaim)
-            {
-              --this->size_;
-            }
+            --this->size_;
 
           ++number_of_timers_expired;
-         }
+        }
     }
 
   if (number_of_timers_expired > 0)

--- a/ACE/ace/Timer_Heap.h
+++ b/ACE/ace/Timer_Heap.h
@@ -12,8 +12,11 @@
 #define ACE_TIMER_HEAP_H
 #include /**/ "ace/pre.h"
 
-#include "ace/Timer_Heap_T.h"
+#include "ace/Event_Handler.h"
 #include "ace/Event_Handler_Handle_Timeout_Upcall.h"
+#include "ace/Synch_Traits.h"
+#include "ace/Time_Policy.h"
+#include "ace/Timer_Heap_T.h"
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 # pragma once
@@ -24,21 +27,21 @@ ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 // The following typedefs are here for ease of use and backward
 // compatibility.
 
-typedef ACE_Timer_Heap_T<ACE_Event_Handler *,
+typedef ACE_Timer_Heap_T<ACE_Event_Handler,
                          ACE_Event_Handler_Handle_Timeout_Upcall,
-                         ACE_SYNCH_RECURSIVE_MUTEX>
+                         ACE_SYNCH_RECURSIVE_MUTEX,
+                         ACE_Default_Time_Policy>
         ACE_Timer_Heap;
 
-typedef ACE_Timer_Heap_Iterator_T<ACE_Event_Handler *,
-                                  ACE_Event_Handler_Handle_Timeout_Upcall,
-                                  ACE_SYNCH_RECURSIVE_MUTEX>
-        ACE_Timer_Heap_Iterator;
+typedef ACE_Timer_Heap::ITERATOR_T ACE_Timer_Heap_Iterator;
 
-typedef ACE_Timer_Heap_T<ACE_Event_Handler *,
+typedef ACE_Timer_Heap_T<ACE_Event_Handler,
                          ACE_Event_Handler_Handle_Timeout_Upcall,
                          ACE_SYNCH_RECURSIVE_MUTEX,
                          ACE_FPointer_Time_Policy>
         ACE_Timer_Heap_Variable_Time_Source;
+
+typedef ACE_Timer_Heap_Variable_Time_Source::ITERATOR_T ACE_Timer_Heap_Variable_Time_Source_Iterator;
 
 ACE_END_VERSIONED_NAMESPACE_DECL
 

--- a/ACE/ace/Timer_Heap_T.cpp
+++ b/ACE/ace/Timer_Heap_T.cpp
@@ -22,8 +22,8 @@
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
-ACE_ALLOC_HOOK_DEFINE_Tccct(ACE_Timer_Heap_Iterator_T)
-ACE_ALLOC_HOOK_DEFINE_Tccct(ACE_Timer_Heap_T)
+ACE_ALLOC_HOOK_DEFINE_Tccct (ACE_Timer_Heap_Iterator_T)
+ACE_ALLOC_HOOK_DEFINE_Tccct (ACE_Timer_Heap_T)
 
 // Define some simple inlined functions to clarify the code.
 inline size_t
@@ -103,7 +103,7 @@ ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::ACE_Timer_Heap_T (
   FUNCTOR *upcall_functor,
   ACE_Free_List<ACE_Timer_Node_T <TYPE> > *freelist,
   TIME_POLICY const & time_policy)
-  : Base_Time_Policy (upcall_functor,
+  : inherited (upcall_functor,
       freelist,
       time_policy),
     max_size_ (size),
@@ -164,7 +164,7 @@ ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::ACE_Timer_Heap_T (
     }
 
   ACE_NEW (iterator_,
-           HEAP_ITERATOR (*this));
+           ITERATOR_T (*this));
 }
 
 // Note that timer_ids_curr_ and timer_ids_min_free_ both start at 0.
@@ -176,7 +176,7 @@ ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::ACE_Timer_Heap_T (
   FUNCTOR *upcall_functor,
   ACE_Free_List<ACE_Timer_Node_T <TYPE> > *freelist,
   TIME_POLICY const & time_policy)
-  : Base_Time_Policy (upcall_functor,
+  : inherited (upcall_functor,
           freelist,
           time_policy),
     max_size_ (ACE_DEFAULT_TIMERS),
@@ -218,7 +218,7 @@ ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::ACE_Timer_Heap_T (
     this->timer_ids_[i] = -1;
 
   ACE_NEW (iterator_,
-           HEAP_ITERATOR (*this));
+           ITERATOR_T (*this));
 }
 
 template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY>
@@ -272,7 +272,7 @@ ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::close (void)
       // back to the handler. Prevents a handler from trying to cancel_timer()
       // inside handle_close(), ripping the current timer node out from
       // under us.
-      TYPE eh = this->heap_[i]->get_type ();
+      TYPE* eh = this->heap_[i]->get_type ();
       const void *act = this->heap_[i]->get_act ();
       this->free_node (this->heap_[i]);
       this->upcall_functor ().deletion (*this, eh, act);
@@ -282,8 +282,7 @@ ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::close (void)
   return 0;
 }
 
-template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY>
-long
+template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> long
 ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::pop_freelist (void)
 {
   ACE_TRACE ("ACE_Timer_Heap_T::pop_freelist");
@@ -315,8 +314,7 @@ ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::pop_freelist (void)
   return static_cast<long> (this->timer_ids_curr_);
 }
 
-template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY>
-void
+template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> void
 ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::push_freelist (long old_id)
 {
   ACE_TRACE ("ACE_Timer_Heap_T::push_freelist");
@@ -340,8 +338,7 @@ ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::push_freelist (long old_
   return;
 }
 
-template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY>
-long
+template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> long
 ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::timer_id (void)
 {
   ACE_TRACE ("ACE_Timer_Heap_T::timer_id");
@@ -352,8 +349,7 @@ ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::timer_id (void)
 
 // Checks if queue is empty.
 
-template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY>
-bool
+template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> bool
 ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::is_empty (void) const
 {
   ACE_TRACE ("ACE_Timer_Heap_T::is_empty");
@@ -361,8 +357,7 @@ ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::is_empty (void) const
   return this->cur_size_ == 0;
 }
 
-template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY>
-ACE_Timer_Queue_Iterator_T<TYPE> &
+template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> ACE_Timer_Queue_Iterator_T<TYPE> &
 ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::iter (void)
 {
   this->iterator_->first ();
@@ -378,8 +373,7 @@ ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::earliest_time (void) con
   return this->heap_[0]->get_timer_value ();
 }
 
-template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY>
-void
+template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> void
 ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::dump (void) const
 {
 #if defined (ACE_HAS_DUMP)
@@ -416,8 +410,7 @@ ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::dump (void) const
 #endif /* ACE_HAS_DUMP */
 }
 
-template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY>
-void
+template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> void
 ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::copy (
   size_t slot,
   ACE_Timer_Node_T<TYPE> *moved_node)
@@ -437,8 +430,7 @@ ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::copy (
 // this function must call either free_node (to reclaim the timer ID
 // and the timer node memory, as well as decrement the size of the queue)
 // or reschedule (to reinsert the node in the heap at a new time).
-template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY>
-ACE_Timer_Node_T<TYPE> *
+template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> ACE_Timer_Node_T<TYPE> *
 ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::remove (size_t slot)
 {
   ACE_Timer_Node_T<TYPE> *removed_node =
@@ -462,7 +454,7 @@ ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::remove (size_t slot)
       // the corresponding slot in the parallel <timer_ids> array.
       this->copy (slot, moved_node);
 
-      // If the <moved_node->time_value_> is great than or equal its
+      // If the <moved_node->time_value_> is greater than or equal its
       // parent it needs be moved down the heap.
       size_t parent = ACE_HEAP_PARENT (slot);
 
@@ -516,8 +508,7 @@ ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::reheap_down (
   this->copy (slot, moved_node);
 }
 
-template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY>
-void
+template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> void
 ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::reheap_up (
   ACE_Timer_Node_T<TYPE> *moved_node,
   size_t slot,
@@ -546,8 +537,7 @@ ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::reheap_up (
               moved_node);
 }
 
-template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY>
-void
+template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> void
 ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::insert (
   ACE_Timer_Node_T<TYPE> *new_node)
 {
@@ -560,8 +550,7 @@ ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::insert (
   this->cur_size_++;
 }
 
-template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY>
-void
+template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> void
 ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::grow_heap (void)
 {
   // All the containers will double in size from max_size_.
@@ -663,8 +652,7 @@ ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::grow_heap (void)
 // Reschedule a periodic timer.  This function must be called with the
 // mutex lock held.
 
-template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY>
-void
+template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> void
 ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::reschedule (
   ACE_Timer_Node_T<TYPE> *expired)
 {
@@ -680,8 +668,7 @@ ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::reschedule (
   this->insert (expired);
 }
 
-template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY>
-ACE_Timer_Node_T<TYPE> *
+template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> ACE_Timer_Node_T<TYPE> *
 ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::alloc_node (void)
 {
   ACE_Timer_Node_T<TYPE> *temp = 0;
@@ -709,8 +696,7 @@ ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::alloc_node (void)
   return temp;
 }
 
-template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY>
-void
+template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> void
 ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::free_node (
   ACE_Timer_Node_T<TYPE> *node)
 {
@@ -730,10 +716,9 @@ ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::free_node (
 // Insert a new timer that expires at time future_time; if interval is
 // > 0, the handler will be reinvoked periodically.
 
-template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY>
-long
+template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> long
 ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::schedule_i (
-  const TYPE &type,
+  TYPE *handler,
   const void *act,
   const ACE_Time_Value &future_time,
   const ACE_Time_Value &interval)
@@ -751,7 +736,7 @@ ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::schedule_i (
       ACE_ALLOCATOR_RETURN (temp,
                             this->alloc_node (),
                             -1);
-      temp->set (type,
+      temp->set (handler,
                  act,
                  future_time,
                  interval,
@@ -768,11 +753,11 @@ ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::schedule_i (
 // Locate and remove the single timer with a value of @a timer_id from
 // the timer queue.
 
-template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY>
-int
-ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::cancel (long timer_id,
-                                                   const void **act,
-                                                   int dont_call)
+template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> int
+ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::cancel (
+  long timer_id,
+  const void **act,
+  int dont_call)
 {
   ACE_TRACE ("ACE_Timer_Heap_T::cancel");
   ACE_MT (ACE_GUARD_RETURN (ACE_LOCK, ace_mon, this->mutex_, -1));
@@ -825,10 +810,10 @@ ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::cancel (long timer_id,
 
 // Locate and update the inteval on the timer_id
 
-template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY>
-int
-ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::reset_interval (long timer_id,
-                                                           const ACE_Time_Value &interval)
+template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> int
+ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::reset_interval (
+  long timer_id,
+  const ACE_Time_Value &interval)
 {
   ACE_TRACE ("ACE_Timer_Heap_T::reset_interval");
   ACE_MT (ACE_GUARD_RETURN (ACE_LOCK, ace_mon, this->mutex_, -1));
@@ -861,13 +846,12 @@ ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::reset_interval (long tim
 
 // Locate and remove all values of @a type from the timer queue.
 
-template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY>
-int
-ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::cancel (const TYPE &type,
-                                                   int dont_call)
+template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> int
+ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::cancel (
+  TYPE *handler,
+  int dont_call)
 {
   ACE_TRACE ("ACE_Timer_Heap_T::cancel");
-
   ACE_MT (ACE_GUARD_RETURN (ACE_LOCK, ace_mon, this->mutex_, -1));
 
   int number_of_cancellations = 0;
@@ -876,7 +860,7 @@ ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::cancel (const TYPE &type
 
   for (size_t i = 0; i < this->cur_size_; )
     {
-      if (this->heap_[i]->get_type () == type)
+      if (this->heap_[i]->get_type () == handler)
         {
           ACE_Timer_Node_T<TYPE> *temp = this->remove (i);
 
@@ -898,7 +882,7 @@ ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::cancel (const TYPE &type
 
   // cancel_type() called once per <type>.
   this->upcall_functor ().cancel_type (*this,
-                                       type,
+                                       handler,
                                        dont_call,
                                        cookie);
 
@@ -908,7 +892,7 @@ ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::cancel (const TYPE &type
     {
       // cancel_timer() called once per <timer>.
       this->upcall_functor ().cancel_timer (*this,
-                                            type,
+                                            handler,
                                             dont_call,
                                             cookie);
     }
@@ -918,8 +902,7 @@ ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::cancel (const TYPE &type
 
 // Returns the earliest node or returns 0 if the heap is empty.
 
-template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY>
-ACE_Timer_Node_T <TYPE> *
+template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> ACE_Timer_Node_T <TYPE> *
 ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::remove_first (void)
 {
   ACE_TRACE ("ACE_Timer_Heap_T::remove_first");
@@ -930,8 +913,7 @@ ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::remove_first (void)
   return this->remove (0);
 }
 
-template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY>
-ACE_Timer_Node_T <TYPE> *
+template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> ACE_Timer_Node_T <TYPE> *
 ACE_Timer_Heap_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::get_first (void)
 {
   ACE_TRACE ("ACE_Timer_Heap_T::get_first");

--- a/ACE/ace/Timer_List.h
+++ b/ACE/ace/Timer_List.h
@@ -24,12 +24,13 @@ ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
 // The following typedefs are here for ease of use and backward
 // compatibility.
-typedef ACE_Timer_List_T<ACE_Event_Handler *,
+typedef ACE_Timer_List_T<ACE_Event_Handler,
                          ACE_Event_Handler_Handle_Timeout_Upcall,
-                         ACE_SYNCH_RECURSIVE_MUTEX>
+                         ACE_SYNCH_RECURSIVE_MUTEX,
+                         ACE_Default_Time_Policy>
         ACE_Timer_List;
 
-typedef ACE_Timer_List_Iterator_T<ACE_Event_Handler *,
+typedef ACE_Timer_List_Iterator_T<ACE_Event_Handler,
                                   ACE_Event_Handler_Handle_Timeout_Upcall,
                                   ACE_SYNCH_RECURSIVE_MUTEX,
                                   ACE_Default_Time_Policy>

--- a/ACE/ace/Timer_List_T.cpp
+++ b/ACE/ace/Timer_List_T.cpp
@@ -9,15 +9,14 @@
 # pragma once
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
-
-
 // Default Constructor
 
 template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY>
-ACE_Timer_List_Iterator_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::ACE_Timer_List_Iterator_T (List& lst)
+ACE_Timer_List_Iterator_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::ACE_Timer_List_Iterator_T (
+  List& lst)
   : list_ (lst)
 {
-  this->first();
+  this->first ();
 }
 
 template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY>
@@ -30,7 +29,7 @@ ACE_Timer_List_Iterator_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::~ACE_Timer_List
 template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> void
 ACE_Timer_List_Iterator_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::first (void)
 {
-  this->current_node_ = this->list_.get_first();
+  this->current_node_ = this->list_.get_first ();
 }
 
 // Positions the iterator at the next node in the Timer Queue
@@ -39,7 +38,7 @@ template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> void
 ACE_Timer_List_Iterator_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::next (void)
 {
   // Make sure that if we are at the end, we don't wrap around
-  if (! this->isdone())
+  if (! this->isdone ())
     this->current_node_ = this->current_node_->get_next ();
   if (this->current_node_  == this->list_.head_)
     this->current_node_ = 0;
@@ -58,7 +57,7 @@ ACE_Timer_List_Iterator_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::isdone (void) c
 template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> ACE_Timer_Node_T<TYPE> *
 ACE_Timer_List_Iterator_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::item (void)
 {
-  if (! this->isdone())
+  if (! this->isdone ())
     return this->current_node_;
   return 0;
 }
@@ -78,19 +77,24 @@ ACE_Timer_List_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::iter (void)
 // Create an empty list.
 
 template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY>
-ACE_Timer_List_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::ACE_Timer_List_T (FUNCTOR* uf,
-                    FreeList* fl,
-                    TIME_POLICY const & time_policy)
-  : Base_Timer_Queue (uf, fl, time_policy)
-  , head_ (new ACE_Timer_Node_T<TYPE>)
+ACE_Timer_List_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::ACE_Timer_List_T (
+  FUNCTOR* uf,
+  FreeList* fl,
+  TIME_POLICY const & time_policy)
+  : inherited (uf, fl, time_policy)
+  , head_ (0)
   , id_counter_ (0)
 {
   ACE_TRACE ("ACE_Timer_List_T::ACE_Timer_List_T");
 
+  ACE_NEW (head_,
+           ACE_Timer_Node_T<TYPE> ());
+  ACE_ASSERT (head_);
   this->head_->set_next (this->head_);
   this->head_->set_prev (this->head_);
 
-  ACE_NEW (iterator_, Iterator(*this));
+  ACE_NEW (iterator_,
+           ITERATOR_T (*this));
 }
 
 
@@ -100,7 +104,7 @@ template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> bool
 ACE_Timer_List_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::is_empty (void) const
 {
   ACE_TRACE ("ACE_Timer_List_T::is_empty");
-  return this->get_first_i() == 0;
+  return this->get_first_i () == 0;
 }
 
 
@@ -110,7 +114,7 @@ template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> const
 ACE_Timer_List_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::earliest_time (void) const
 {
   ACE_TRACE ("ACE_Timer_List_T::earliest_time");
-  ACE_Timer_Node_T<TYPE>* first = this->get_first_i();
+  ACE_Timer_Node_T<TYPE>* first = this->get_first_i ();
   if (first != 0)
     return first->get_timer_value ();
   return ACE_Time_Value::zero;
@@ -137,18 +141,18 @@ template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> int
 ACE_Timer_List_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::close (void)
 {
   ACE_TRACE ("ACE_Timer_List_T::close");
-  ACE_MT (ACE_GUARD_RETURN (ACE_LOCK, ace_mon, this->mutex_, -1));
+  //ACE_MT (ACE_GUARD_RETURN (ACE_LOCK, ace_mon, this->mutex_, -1));
 
   // Remove all remaining items in the list.
-  if (!this->is_empty())
+  if (!this->is_empty ())
     {
-      for (ACE_Timer_Node_T<TYPE>* n = this->get_first();
+      for (ACE_Timer_Node_T<TYPE>* n = this->get_first ();
            n != this->head_;
            )
         {
           this->upcall_functor ().deletion (*this,
-                                            n->get_type(),
-                                            n->get_act());
+                                            n->get_type (),
+                                            n->get_act ());
 
           ACE_Timer_Node_T<TYPE> *next =
             n->get_next ();
@@ -172,9 +176,9 @@ ACE_Timer_List_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::dump (void) const
 
   int count = 0;
 
-  ACE_Timer_Node_T<TYPE>* n = this->get_first_i();
+  ACE_Timer_Node_T<TYPE>* n = this->get_first_i ();
   if (n != 0) {
-    for (; n != this->head_; n = n->get_next()) {
+    for (; n != this->head_; n = n->get_next ()) {
       ++count;
     }
   }
@@ -192,7 +196,7 @@ template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> void
 ACE_Timer_List_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::reschedule (ACE_Timer_Node_T<TYPE>* n)
 {
   ACE_TRACE ("ACE_Timer_List_T::reschedule");
-  this->schedule_i(n, n->get_timer_value());
+  this->schedule_i (n, n->get_timer_value ());
 }
 
 
@@ -200,21 +204,22 @@ ACE_Timer_List_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::reschedule (ACE_Timer_No
 // is > 0, the handler will be reinvoked periodically.
 
 template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> long
-ACE_Timer_List_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::schedule_i (const TYPE &type,
-                                                       const void *act,
-                                                       const ACE_Time_Value &future_time,
-                                                       const ACE_Time_Value &interval)
+ACE_Timer_List_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::schedule_i (
+  TYPE *handler,
+  const void *act,
+  const ACE_Time_Value &future_time,
+  const ACE_Time_Value &interval)
 {
   ACE_TRACE ("ACE_Timer_List_T::schedule_i");
 
-  ACE_Timer_Node_T<TYPE>* n = this->alloc_node();
+  ACE_Timer_Node_T<TYPE>* n = this->alloc_node ();
 
   if (n != 0)
   {
     long id = this->id_counter_++;
 
     if (id != -1) {
-      n->set (type, act, future_time, interval, 0, 0, id);
+      n->set (handler, act, future_time, interval, 0, 0, id);
       this->schedule_i (n, future_time);
     }
     return id;
@@ -227,14 +232,15 @@ ACE_Timer_List_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::schedule_i (const TYPE &
 
 /// The shared scheduling functionality between schedule() and reschedule()
 template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> void
-ACE_Timer_List_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::schedule_i (ACE_Timer_Node_T<TYPE>* n,
-                                                       const ACE_Time_Value& expire)
+ACE_Timer_List_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::schedule_i (
+  ACE_Timer_Node_T<TYPE>* n,
+  const ACE_Time_Value& expire)
 {
-  if (this->is_empty()) {
-    n->set_prev(this->head_);
-    n->set_next(this->head_);
-    this->head_->set_prev(n);
-    this->head_->set_next(n);
+  if (this->is_empty ()) {
+    n->set_prev (this->head_);
+    n->set_next (this->head_);
+    this->head_->set_prev (n);
+    this->head_->set_next (n);
     return;
   }
 
@@ -242,27 +248,27 @@ ACE_Timer_List_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::schedule_i (ACE_Timer_No
   // this minimizes the search in the extreme case when lots of timers are
   // scheduled for exactly the same time, and it also assumes that most of
   // the timers will be scheduled later than existing timers.
-  ACE_Timer_Node_T<TYPE>* p = this->head_->get_prev();
-  while (p != this->head_ && p->get_timer_value() > expire)
-    p = p->get_prev();
+  ACE_Timer_Node_T<TYPE>* p = this->head_->get_prev ();
+  while (p != this->head_ && p->get_timer_value () > expire)
+    p = p->get_prev ();
 
   // insert after
-  n->set_prev(p);
-  n->set_next(p->get_next());
-  p->get_next()->set_prev(n);
-  p->set_next(n);
+  n->set_prev (p);
+  n->set_next (p->get_next ());
+  p->get_next ()->set_prev (n);
+  p->set_next (n);
 }
 
 template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY>
 ACE_Timer_Node_T<TYPE>*
 ACE_Timer_List_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::find_node (long timer_id) const
 {
-  ACE_Timer_Node_T<TYPE>* n = this->get_first_i();
+  ACE_Timer_Node_T<TYPE>* n = this->get_first_i ();
   if (n == 0)
     return 0;
 
-  for (; n != this->head_; n = n->get_next()) {
-    if (n->get_timer_id() == timer_id) {
+  for (; n != this->head_; n = n->get_next ()) {
+    if (n->get_timer_id () == timer_id) {
       return n;
     }
   }
@@ -271,14 +277,15 @@ ACE_Timer_List_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::find_node (long timer_id
 
 // Locate and update the inteval on the timer_id
 template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> int
-ACE_Timer_List_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::reset_interval (long timer_id,
-                                                           const ACE_Time_Value &interval)
+ACE_Timer_List_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::reset_interval (
+  long timer_id,
+  const ACE_Time_Value &interval)
 {
   ACE_TRACE ("ACE_Timer_List_T::reset_interval");
   ACE_MT (ACE_GUARD_RETURN (ACE_LOCK, ace_mon, this->mutex_, -1));
-  ACE_Timer_Node_T<TYPE>* n = this->find_node(timer_id);
+  ACE_Timer_Node_T<TYPE>* n = this->find_node (timer_id);
   if (n != 0) {
-    n->set_interval(interval); // The interval will take effect the next time this node is expired.
+    n->set_interval (interval); // The interval will take effect the next time this node is expired.
     return 0;
   }
   return -1;
@@ -287,13 +294,14 @@ ACE_Timer_List_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::reset_interval (long tim
 // Locate and remove the single <ACE_Event_Handler> with a value of
 // @a timer_id from the timer queue.
 template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> int
-ACE_Timer_List_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::cancel (long timer_id,
-                                                   const void **act,
-                                                   int skip_close)
+ACE_Timer_List_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::cancel (
+  long timer_id,
+  const void **act,
+  int dont_call)
 {
   ACE_TRACE ("ACE_Timer_List_T::cancel");
   ACE_MT (ACE_GUARD_RETURN (ACE_LOCK, ace_mon, this->mutex_, -1));
-  ACE_Timer_Node_T<TYPE>* n = this->find_node(timer_id);
+  ACE_Timer_Node_T<TYPE>* n = this->find_node (timer_id);
   if (n != 0)
     {
       if (act != 0)
@@ -305,13 +313,13 @@ ACE_Timer_List_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::cancel (long timer_id,
       // cancel_type() called once per <type>.
       this->upcall_functor ().cancel_type (*this,
                                            n->get_type (),
-                                           skip_close,
+                                           dont_call,
                                            cookie);
 
       // cancel_timer() called once per <timer>.
       this->upcall_functor ().cancel_timer (*this,
                                             n->get_type (),
-                                            skip_close,
+                                            dont_call,
                                             cookie);
 
       this->cancel_i (n);
@@ -324,7 +332,9 @@ ACE_Timer_List_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::cancel (long timer_id,
 
 // Locate and remove all values of <handler> from the timer queue.
 template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> int
-ACE_Timer_List_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::cancel (const TYPE &type, int skip_close)
+ACE_Timer_List_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::cancel (
+  TYPE *handler,
+  int dont_call)
 {
   ACE_TRACE ("ACE_Timer_List_T::cancel");
 
@@ -336,22 +346,22 @@ ACE_Timer_List_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::cancel (const TYPE &type
 
   if (!this->is_empty ())
     {
-      for (ACE_Timer_Node_T<TYPE>* n = this->get_first();
+      for (ACE_Timer_Node_T<TYPE>* n = this->get_first ();
            n != this->head_;
            )
         {
-          if (n->get_type() == type) // Note: Typically Type is an ACE_Event_Handler*
+          if (n->get_type () == handler) // Note: Typically Type is an ACE_Event_Handler*
             {
               ++num_canceled;
 
               ACE_Timer_Node_T<TYPE>* tmp = n;
-              n = n->get_next();
+              n = n->get_next ();
 
               this->cancel_i (tmp);
             }
           else
             {
-              n = n->get_next();
+              n = n->get_next ();
             }
         }
     }
@@ -360,8 +370,8 @@ ACE_Timer_List_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::cancel (const TYPE &type
 
   // cancel_type() called once per <type>.
   this->upcall_functor ().cancel_type (*this,
-                                       type,
-                                       skip_close,
+                                       handler,
+                                       dont_call,
                                        cookie);
 
   for (int i = 0;
@@ -370,8 +380,8 @@ ACE_Timer_List_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::cancel (const TYPE &type
     {
       // cancel_timer() called once per <timer>.
       this->upcall_functor ().cancel_timer (*this,
-                                            type,
-                                            skip_close,
+                                            handler,
+                                            dont_call,
                                             cookie);
     }
 
@@ -379,17 +389,19 @@ ACE_Timer_List_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::cancel (const TYPE &type
 }
 
 template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> void
-ACE_Timer_List_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::unlink (ACE_Timer_Node_T<TYPE>* n)
+ACE_Timer_List_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::unlink (
+  ACE_Timer_Node_T<TYPE>* n)
 {
-  n->get_prev()->set_next(n->get_next());
-  n->get_next()->set_prev(n->get_prev());
-  n->set_prev(0);
-  n->set_next(0);
+  n->get_prev ()->set_next (n->get_next ());
+  n->get_next ()->set_prev (n->get_prev ());
+  n->set_prev (0);
+  n->set_next (0);
 }
 
 /// Shared subset of the two cancel() methods.
 template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> void
-ACE_Timer_List_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::cancel_i (ACE_Timer_Node_T<TYPE>* n)
+ACE_Timer_List_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::cancel_i (
+  ACE_Timer_Node_T<TYPE>* n)
 {
   this->unlink (n);
   this->free_node (n);
@@ -400,29 +412,27 @@ template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> ACE_T
 ACE_Timer_List_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::get_first (void)
 {
   ACE_TRACE ("ACE_Timer_List_T::get_first");
-  return this->get_first_i();
+  return this->get_first_i ();
 }
 
 template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> ACE_Timer_Node_T<TYPE> *
 ACE_Timer_List_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::get_first_i (void) const
 {
   ACE_TRACE ("ACE_Timer_List_T::get_first_i");
-  ACE_Timer_Node_T<TYPE>* first = this->head_->get_next();
+  ACE_Timer_Node_T<TYPE>* first = this->head_->get_next ();
   if (first != this->head_) // Note : is_empty() uses get_first()
     return first;
   return 0;
 }
 
-
 // Removes the first node on the list and returns it.
-
 template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> ACE_Timer_Node_T<TYPE> *
 ACE_Timer_List_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::remove_first (void)
 {
   ACE_TRACE ("ACE_Timer_List_T::remove_first");
-  ACE_Timer_Node_T<TYPE>* first = this->get_first();
+  ACE_Timer_Node_T<TYPE>* first = this->get_first ();
   if (first != 0) {
-    this->unlink(first);
+    this->unlink (first);
     return first;
   }
   return 0;

--- a/ACE/ace/Timer_Queue.h
+++ b/ACE/ace/Timer_Queue.h
@@ -14,31 +14,24 @@
 
 #include /**/ "ace/pre.h"
 
-#include "ace/Synch_Traits.h"
-
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 # pragma once
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
-#include "ace/Timer_Queuefwd.h"
-#include "ace/Timer_Queue_T.h"
-#if defined (ACE_HAS_THREADS)
-#  include "ace/Recursive_Thread_Mutex.h"
-#else
-#  include "ace/Null_Mutex.h"
-#endif /* ACE_HAS_THREADS */
+#include "ace/Event_Handler.h"
+#include "ace/Timer_Queue_Iterator.h"
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
 // The following typedef are here for ease of use and backward
 // compatibility.
-typedef ACE_Timer_Node_Dispatch_Info_T<ACE_Event_Handler *>
+typedef ACE_Timer_Node_Dispatch_Info_T<ACE_Event_Handler>
         ACE_Timer_Node_Dispatch_Info;
 
-typedef ACE_Timer_Node_T<ACE_Event_Handler *>
+typedef ACE_Timer_Node_T<ACE_Event_Handler>
         ACE_Timer_Node;
 
-typedef ACE_Timer_Queue_Iterator_T<ACE_Event_Handler *>
+typedef ACE_Timer_Queue_Iterator_T<ACE_Event_Handler>
         ACE_Timer_Queue_Iterator;
 
 ACE_END_VERSIONED_NAMESPACE_DECL

--- a/ACE/ace/Timer_Queue_Adapters.cpp
+++ b/ACE/ace/Timer_Queue_Adapters.cpp
@@ -15,12 +15,23 @@
 #  include "ace/Timer_Queue_Adapters.inl"
 # endif /* __ACE_INLINE__ */
 
-#include "ace/Reverse_Lock_T.h"
-#include "ace/Signal.h"
 #include "ace/OS_NS_unistd.h"
 #include "ace/OS_NS_sys_time.h"
+#include "ace/Reverse_Lock_T.h"
+#include "ace/Signal.h"
+#include "ace/Thread_Manager.h"
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
+
+template <class TYPE> int
+ACE_Timer_Queue_Adapter_Base<TYPE>::cancel (TYPE*,
+                                            int)
+{
+  ACE_ASSERT (false);
+  ACE_NOTSUP_RETURN (-1);
+
+  ACE_NOTREACHED (return -1;)
+}
 
 template <class TQ, class TYPE> TQ &
 ACE_Async_Timer_Queue_Adapter<TQ, TYPE>::timer_queue (void)
@@ -29,14 +40,22 @@ ACE_Async_Timer_Queue_Adapter<TQ, TYPE>::timer_queue (void)
 }
 
 template <class TQ, class TYPE> int
-ACE_Async_Timer_Queue_Adapter<TQ, TYPE>::cancel (long timer_id,
-                                           const void **act)
+ACE_Async_Timer_Queue_Adapter<TQ, TYPE>::cancel (
+  long timer_id,
+  const void **act,
+  int dont_call)
 {
   // Block designated signals.
   ACE_Sig_Guard sg (&this->mask_);
   ACE_UNUSED_ARG (sg);
 
-  return this->timer_queue_.cancel (timer_id, act);
+  return this->timer_queue_.cancel (timer_id, act, dont_call);
+}
+
+template <class TQ, class TYPE> ACE_Time_Value
+ACE_Async_Timer_Queue_Adapter<TQ, TYPE>::gettimeofday (void)
+{
+  return this->timer_queue_.gettimeofday ();
 }
 
 template <class TQ, class TYPE> int
@@ -68,10 +87,11 @@ ACE_Async_Timer_Queue_Adapter<TQ, TYPE>::schedule_ualarm (void)
 }
 
 template <class TQ, class TYPE> long
-ACE_Async_Timer_Queue_Adapter<TQ, TYPE>::schedule (TYPE eh,
-                                             const void *act,
-                                             const ACE_Time_Value &future_time,
-                                             const ACE_Time_Value &interval)
+ACE_Async_Timer_Queue_Adapter<TQ, TYPE>::schedule (
+  TYPE *handler,
+  const void *act,
+  const ACE_Time_Value &future_time,
+  const ACE_Time_Value &interval)
 {
   ACE_UNUSED_ARG (act);
   ACE_UNUSED_ARG (interval);
@@ -81,7 +101,7 @@ ACE_Async_Timer_Queue_Adapter<TQ, TYPE>::schedule (TYPE eh,
   ACE_UNUSED_ARG (sg);
 
   // @@ We still need to implement interval timers...
-  long tid = this->timer_queue_.schedule (eh, act, future_time);
+  long tid = this->timer_queue_.schedule (handler, act, future_time);
 
   if (tid == -1)
     ACELIB_ERROR_RETURN ((LM_ERROR,
@@ -96,7 +116,8 @@ ACE_Async_Timer_Queue_Adapter<TQ, TYPE>::schedule (TYPE eh,
 }
 
 template <class TQ, class TYPE>
-ACE_Async_Timer_Queue_Adapter<TQ, TYPE>::ACE_Async_Timer_Queue_Adapter (ACE_Sig_Set *mask)
+ACE_Async_Timer_Queue_Adapter<TQ, TYPE>::ACE_Async_Timer_Queue_Adapter (
+  ACE_Sig_Set *mask)
   // If <mask> == 0, block *all* signals when the SIGARLM handler is
   // running, else just block those in the mask.
   : mask_ (mask)
@@ -105,7 +126,7 @@ ACE_Async_Timer_Queue_Adapter<TQ, TYPE>::ACE_Async_Timer_Queue_Adapter (ACE_Sig_
   // signals when SIGALRM is running.  Also, we always restart system
   // calls that are interrupted by the signals.
 
-  ACE_Sig_Action sa ((ACE_SignalHandler) 0,
+  ACE_Sig_Action sa ((ACE_SignalHandler)0,
                      this->mask_,
                      SA_RESTART);
 
@@ -120,9 +141,10 @@ ACE_Async_Timer_Queue_Adapter<TQ, TYPE>::ACE_Async_Timer_Queue_Adapter (ACE_Sig_
 // occurs.
 
 template <class TQ, class TYPE> int
-ACE_Async_Timer_Queue_Adapter<TQ, TYPE>::handle_signal (int signum,
-                                                  siginfo_t *,
-                                                  ucontext_t *)
+ACE_Async_Timer_Queue_Adapter<TQ, TYPE>::handle_signal (
+  int signum,
+  siginfo_t *,
+  ucontext_t *)
 {
   switch (signum)
     {
@@ -146,19 +168,20 @@ ACE_Async_Timer_Queue_Adapter<TQ, TYPE>::handle_signal (int signum,
       }
     default:
       ACELIB_ERROR_RETURN ((LM_ERROR,
-                         "unexpected signal %S\n",
+                            ACE_TEXT ("unexpected signal %S\n"),
                          signum),
                         -1);
       /* NOTREACHED */
     }
 }
 
-template<class TQ, class TYPE>
-ACE_Thread_Timer_Queue_Adapter<TQ, TYPE>::ACE_Thread_Timer_Queue_Adapter (ACE_Thread_Manager *tm,
-                                                                    TQ* timer_queue)
+template <class TQ, class TYPE>
+ACE_Thread_Timer_Queue_Adapter<TQ, TYPE>::ACE_Thread_Timer_Queue_Adapter (
+  ACE_Thread_Manager *tm,
+  TQ* timer_queue)
   : ACE_Task_Base (tm),
-    timer_queue_(timer_queue),
-    delete_timer_queue_(false),
+    timer_queue_ (timer_queue),
+    delete_timer_queue_ (false),
     condition_ (mutex_),
     active_ (true), // Assume that we start in active mode.
     thr_id_ (ACE_OS::NULL_thread)
@@ -166,12 +189,12 @@ ACE_Thread_Timer_Queue_Adapter<TQ, TYPE>::ACE_Thread_Timer_Queue_Adapter (ACE_Th
   if (timer_queue_ == 0)
     {
       ACE_NEW (this->timer_queue_,
-               TQ);
+               TQ ());
       this->delete_timer_queue_ = true;
     }
 }
 
-template<class TQ, class TYPE>
+template <class TQ, class TYPE>
 ACE_Thread_Timer_Queue_Adapter<TQ, TYPE>::~ACE_Thread_Timer_Queue_Adapter (void)
 {
   if (this->delete_timer_queue_)
@@ -187,18 +210,18 @@ ACE_Thread_Timer_Queue_Adapter<TQ, TYPE>::~ACE_Thread_Timer_Queue_Adapter (void)
     }
 }
 
-template<class TQ, class TYPE> ACE_SYNCH_RECURSIVE_MUTEX &
+template <class TQ, class TYPE> ACE_SYNCH_RECURSIVE_MUTEX &
 ACE_Thread_Timer_Queue_Adapter<TQ, TYPE>::mutex (void)
 {
   return this->mutex_;
 }
 
-template<class TQ, class TYPE> long
-ACE_Thread_Timer_Queue_Adapter<TQ, TYPE>::schedule
-    (TYPE handler,
-     const void *act,
-     const ACE_Time_Value &future_time,
-     const ACE_Time_Value &interval)
+template <class TQ, class TYPE> long
+ACE_Thread_Timer_Queue_Adapter<TQ, TYPE>::schedule (
+  TYPE *handler,
+  const void *act,
+  const ACE_Time_Value &future_time,
+  const ACE_Time_Value &interval)
 {
   ACE_GUARD_RETURN (ACE_SYNCH_RECURSIVE_MUTEX, guard, this->mutex_, -1);
 
@@ -207,18 +230,38 @@ ACE_Thread_Timer_Queue_Adapter<TQ, TYPE>::schedule
   return result;
 }
 
-template<class TQ, class TYPE> int
-ACE_Thread_Timer_Queue_Adapter<TQ, TYPE>::cancel (long timer_id,
-                                            const void **act)
+template <class TQ, class TYPE> int
+ACE_Thread_Timer_Queue_Adapter<TQ, TYPE>::cancel (
+  TYPE *handler,
+  int dont_call)
 {
   ACE_GUARD_RETURN (ACE_SYNCH_RECURSIVE_MUTEX, guard, this->mutex_, -1);
-
-  int result = this->timer_queue_->cancel (timer_id, act);
+  
+  int result = this->timer_queue_->cancel (handler, dont_call);
   condition_.signal ();
   return result;
 }
 
-template<class TQ, class TYPE> void
+template <class TQ, class TYPE> int
+ACE_Thread_Timer_Queue_Adapter<TQ, TYPE>::cancel (
+  long timer_id,
+  const void **act,
+  int dont_call)
+{
+  ACE_GUARD_RETURN (ACE_SYNCH_RECURSIVE_MUTEX, guard, this->mutex_, -1);
+
+  int result = this->timer_queue_->cancel (timer_id, act, dont_call);
+  condition_.signal ();
+  return result;
+}
+
+template <class TQ, class TYPE> ACE_Time_Value
+ACE_Thread_Timer_Queue_Adapter<TQ, TYPE>::gettimeofday (void)
+{
+  return this->timer_queue_->gettimeofday ();
+}
+
+template <class TQ, class TYPE> void
 ACE_Thread_Timer_Queue_Adapter<TQ, TYPE>::deactivate (void)
 {
   ACE_GUARD (ACE_SYNCH_RECURSIVE_MUTEX, guard, this->mutex_);
@@ -227,7 +270,7 @@ ACE_Thread_Timer_Queue_Adapter<TQ, TYPE>::deactivate (void)
   this->condition_.signal ();
 }
 
-template<class TQ, class TYPE> int
+template <class TQ, class TYPE> int
 ACE_Thread_Timer_Queue_Adapter<TQ, TYPE>::svc (void)
 {
   ACE_GUARD_RETURN (ACE_SYNCH_RECURSIVE_MUTEX, guard, this->mutex_, -1);
@@ -276,7 +319,7 @@ ACE_Thread_Timer_Queue_Adapter<TQ, TYPE>::svc (void)
             {
               // The earliest time on the Timer_Queue lies in future;
               // convert the tv to an absolute time.
-              ACE_Time_Value const tv = this->timer_queue_->gettimeofday () + (tv_earl - tv_curr);
+              ACE_Time_Value const tv = tv_curr + (tv_earl - tv_curr);
               // ACELIB_DEBUG ((LM_DEBUG,  ACE_TEXT ("waiting until %u.%3.3u secs\n"),
               // tv.sec(), tv.msec()));
               this->condition_.wait (&tv);
@@ -302,18 +345,19 @@ ACE_Thread_Timer_Queue_Adapter<TQ, TYPE>::svc (void)
   return 0;
 }
 
-template<class TQ, class TYPE> int
-ACE_Thread_Timer_Queue_Adapter<TQ, TYPE>::activate (long flags,
-                                              int ,
-                                              int ,
-                                              long priority,
-                                              int grp_id,
-                                              ACE_Task_Base *task,
-                                              ACE_hthread_t [],
-                                              void *stack[],
-                                              size_t stack_size[],
-                                              ACE_thread_t thread_ids[],
-                                              const char* thr_name[])
+template <class TQ, class TYPE> int
+ACE_Thread_Timer_Queue_Adapter<TQ, TYPE>::activate (
+  long flags,
+  int,
+  int,
+  long priority,
+  int grp_id,
+  ACE_Task_Base *task,
+  ACE_hthread_t[],
+  void *stack[],
+  size_t stack_size[],
+  ACE_thread_t thread_ids[],
+  const char* thr_name[])
 {
   // Make sure to set this flag in case we were deactivated earlier.
   this->active_ = true;
@@ -332,9 +376,10 @@ ACE_Thread_Timer_Queue_Adapter<TQ, TYPE>::activate (long flags,
 // or cancelling timers on platforms where the timer queue mutex is not
 // recursive.
 
-template<class TQ, class TYPE> int
-ACE_Thread_Timer_Queue_Adapter<TQ, TYPE>::enqueue_command (ACE_Command_Base *cmd,
-                                                     COMMAND_ENQUEUE_POSITION pos)
+template <class TQ, class TYPE> int
+ACE_Thread_Timer_Queue_Adapter<TQ, TYPE>::enqueue_command (
+  ACE_Command_Base *cmd,
+  COMMAND_ENQUEUE_POSITION pos)
 {
   // Serialize access to the command queue.
   ACE_GUARD_RETURN (ACE_SYNCH_MUTEX, guard, this->command_mutex_, -1);
@@ -348,7 +393,7 @@ ACE_Thread_Timer_Queue_Adapter<TQ, TYPE>::enqueue_command (ACE_Command_Base *cmd
 // Dispatches all command objects enqueued in the most recent event
 // handler context.
 
-template<class TQ, class TYPE> int
+template <class TQ, class TYPE> int
 ACE_Thread_Timer_Queue_Adapter<TQ, TYPE>::dispatch_commands (void)
 {
   // Serialize access to the command queue.

--- a/ACE/ace/Timer_Queue_Adapters.h
+++ b/ACE/ace/Timer_Queue_Adapters.h
@@ -13,15 +13,18 @@
 #define ACE_TIMER_QUEUE_ADAPTERS_H
 #include /**/ "ace/pre.h"
 
-#include "ace/Task.h"
-
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 # pragma once
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
+#include "ace/Event_Handler.h"
+#include "ace/OS_NS_Thread.h"
 #include "ace/Signal.h"
 #include "ace/Sig_Handler.h"
 #include "ace/Synch_Traits.h"
+#include "ace/Task.h"
+#include "ace/Thread_Manager.h"
+#include "ace/Time_Value.h"
 
 #if defined (ACE_HAS_DEFERRED_TIMER_COMMANDS)
 #  include "ace/Unbounded_Queue.h"
@@ -32,7 +35,62 @@ ACE_END_VERSIONED_NAMESPACE_DECL
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
-class ACE_Sig_Set;
+/**
+  * @class ACE_Timer_Queue_Adapter_Base
+  *
+  * @brief interface common to the available timer queue adapter strategies
+  *
+  * @note used mainly for testing purposes
+  *
+  */
+template <class TYPE = ACE_Event_Handler>
+class ACE_Timer_Queue_Adapter_Base
+{
+public:
+  virtual ~ACE_Timer_Queue_Adapter_Base (void) {};
+
+  /**
+    * Schedule @a type that will expire at @a future_time,
+    * which is specified in absolute time.  If it expires then @a act is
+    * passed in as the value to the <functor>.  If @a interval is != to
+    * ACE_Time_Value::zero then it is used to reschedule the @a type
+    * automatically, using relative time to the current <gettimeofday>.
+    * This method returns a <timer_id> that is a pointer to a token
+    * which stores information about the event. This <timer_id> can be
+    * used to cancel the timer before it expires.  Returns -1 on
+    * failure.
+    */
+  virtual long schedule (TYPE *handler,
+                         const void *act,
+                         const ACE_Time_Value &future_time,
+                         const ACE_Time_Value &interval = ACE_Time_Value::zero) = 0;
+  
+  /**
+    * Cancel all timer associated with @a type.  If <dont_call> is 0
+    * then the <functor> will be invoked.  Returns number of timers
+    * cancelled.
+    */
+  virtual int cancel (TYPE *type,
+                      int dont_call = 1);
+  
+  /**
+    * Cancel the single timer that matches the @a timer_id value (which
+    * was returned from the <schedule> method).  If act is non-NULL
+    * then it will be set to point to the ``magic cookie'' argument
+    * passed in when the timer was registered.  This makes it possible
+    * to free up the memory and avoid memory leaks.  If <dont_call> is
+    * 0 then the <functor> will be invoked.  Returns 1 if cancellation
+    * succeeded and 0 if the @a timer_id wasn't found.
+    */
+  virtual int cancel (long timer_id,
+                      const void **act = 0,
+                      int dont_call = 1) = 0;
+  
+  /**
+    * Retrieve the time of day (according to the TIME POLICY of the timer queue)
+    */
+  virtual ACE_Time_Value gettimeofday (void) = 0;
+};
 
 /**
  * @class ACE_Async_Timer_Queue_Adapter
@@ -47,11 +105,13 @@ class ACE_Sig_Set;
  *
  * @todo This adapter does not automatically reschedule repeating timers.
  */
-template <class TQ, class TYPE = ACE_Event_Handler*>
-class ACE_Async_Timer_Queue_Adapter : public ACE_Event_Handler
+template <class TQ, class TYPE = ACE_Event_Handler>
+class ACE_Async_Timer_Queue_Adapter
+ : public ACE_Timer_Queue_Adapter_Base<TYPE>
+ , public ACE_Event_Handler
 {
 public:
-  typedef TQ TIMER_QUEUE;
+  typedef TQ TIMER_QUEUE_T;
 
   /// Constructor
   /**
@@ -68,14 +128,21 @@ public:
    * calling expire().  Note that interval timers are not implemented
    * yet.
    */
-  long schedule (TYPE type,
-                 const void *act,
-                 const ACE_Time_Value &future_time,
-                 const ACE_Time_Value &interval = ACE_Time_Value::zero);
+  virtual long schedule (TYPE *handler,
+                         const void *act,
+                         const ACE_Time_Value &future_time,
+                         const ACE_Time_Value &interval = ACE_Time_Value::zero);
 
   /// Cancel the @a timer_id and pass back the @a act if an address is
-  /// passed in.
-  int cancel (long timer_id, const void **act = 0);
+  /// passed in. If <dont_call> is 0 then the <functor> will be invoked.
+  virtual int cancel (long timer_id,
+                      const void **act = 0,
+                      int dont_call = 1);
+
+  /**
+  * Retrieve the time of day (according to the TIME POLICY of the timer queue)
+  */
+  virtual ACE_Time_Value gettimeofday (void);
 
   /// Dispatch all timers with expiry time at or before the current time.
   /// Returns the number of timers expired.
@@ -116,12 +183,14 @@ private:
  * (IMHO) the effort and portability problems discourage their
  * use.
  */
-template <class TQ, class TYPE = ACE_Event_Handler*>
-class ACE_Thread_Timer_Queue_Adapter : public ACE_Task_Base
+template <class TQ, class TYPE = ACE_Event_Handler>
+class ACE_Thread_Timer_Queue_Adapter
+ : public ACE_Timer_Queue_Adapter_Base<TYPE>
+ , public ACE_Task_Base
 {
 public:
   /// Trait for the underlying queue type.
-  typedef TQ TIMER_QUEUE;
+  typedef TQ TIMER_QUEUE_T;
 
 # if defined (ACE_HAS_DEFERRED_TIMER_COMMANDS)
 
@@ -142,14 +211,30 @@ public:
 
   /// Schedule the timer according to the semantics of the <TQ>; wakes
   /// up the dispatching thread.
-  long schedule (TYPE handler,
-                 const void *act,
-                 const ACE_Time_Value &future_time,
-                 const ACE_Time_Value &interval = ACE_Time_Value::zero);
+  virtual long schedule (TYPE *handler,
+                         const void *act,
+                         const ACE_Time_Value &future_time,
+                         const ACE_Time_Value &interval = ACE_Time_Value::zero);
+
+  /**
+    * Cancel all timer associated with @a type.  If <dont_call> is 0
+    * then the <functor> will be invoked.  Returns number of timers
+    * cancelled.
+    */
+  virtual int cancel (TYPE *handler,
+                      int dont_call = 1);
 
   /// Cancel the @a timer_id and return the @a act parameter if an
   /// address is passed in. Also wakes up the dispatching thread.
-  int cancel (long timer_id, const void **act = 0);
+  /// If <dont_call> is 0 then the <functor> will be invoked.
+  virtual int cancel (long timer_id,
+                      const void **act = 0,
+                      int dont_call = 1);
+
+  /**
+    * Retrieve the time of day (according to the TIME POLICY of the timer queue)
+    */
+  virtual ACE_Time_Value gettimeofday (void);
 
   /// Runs the dispatching thread.
   virtual int svc (void);

--- a/ACE/ace/Timer_Queue_Adapters.h
+++ b/ACE/ace/Timer_Queue_Adapters.h
@@ -21,7 +21,7 @@
 
 #include "ace/Signal.h"
 #include "ace/Sig_Handler.h"
-#include "ace/Condition_Recursive_Thread_Mutex.h"
+#include "ace/Synch_Traits.h"
 
 #if defined (ACE_HAS_DEFERRED_TIMER_COMMANDS)
 #  include "ace/Unbounded_Queue.h"

--- a/ACE/ace/Timer_Queue_Iterator.h
+++ b/ACE/ace/Timer_Queue_Iterator.h
@@ -23,7 +23,7 @@ class ACE_Timer_Node_Dispatch_Info_T
 {
 public:
   /// The type of object held in the queue
-  TYPE type_;
+  TYPE* type_;
 
   /// Asynchronous completion token associated with the timer.
   const void *act_;
@@ -51,7 +51,7 @@ public:
   typedef ACE_Timer_Node_Dispatch_Info_T <TYPE> DISPATCH_INFO;
 
   /// Singly linked list
-  void set (const TYPE &type,
+  void set (TYPE *type,
             const void *a,
             const ACE_Time_Value &t,
             const ACE_Time_Value &i,
@@ -59,7 +59,7 @@ public:
             long timer_id);
 
   /// Doubly linked list version
-  void set (const TYPE &type,
+  void set (TYPE *type,
             const void *a,
             const ACE_Time_Value &t,
             const ACE_Time_Value &i,
@@ -70,10 +70,10 @@ public:
   // = Accessors
 
   /// Get the type.
-  TYPE &get_type (void);
+  TYPE *get_type (void);
 
   /// Set the type.
-  void set_type (TYPE &type);
+  void set_type (TYPE *type);
 
   /// Get the asynchronous completion token.
   const void *get_act (void);
@@ -126,7 +126,7 @@ public:
 
 private:
   /// Type of object stored in the Queue
-  TYPE type_;
+  TYPE* type_;
 
   /// Asynchronous completion token associated with the timer.
   const void *act_;

--- a/ACE/ace/Timer_Queue_Iterator.inl
+++ b/ACE/ace/Timer_Queue_Iterator.inl
@@ -2,7 +2,7 @@
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
 template <class TYPE> ACE_INLINE void
-ACE_Timer_Node_T<TYPE>::set (const TYPE &type,
+ACE_Timer_Node_T<TYPE>::set (TYPE *type,
                              const void *a,
                              const ACE_Time_Value &t,
                              const ACE_Time_Value &i,
@@ -18,7 +18,7 @@ ACE_Timer_Node_T<TYPE>::set (const TYPE &type,
 }
 
 template <class TYPE> ACE_INLINE void
-ACE_Timer_Node_T<TYPE>::set (const TYPE &type,
+ACE_Timer_Node_T<TYPE>::set (TYPE *type,
                              const void *a,
                              const ACE_Time_Value &t,
                              const ACE_Time_Value &i,
@@ -35,14 +35,14 @@ ACE_Timer_Node_T<TYPE>::set (const TYPE &type,
   this->timer_id_ = timer_id;
 }
 
-template <class TYPE> ACE_INLINE TYPE &
+template <class TYPE> ACE_INLINE TYPE *
 ACE_Timer_Node_T<TYPE>::get_type (void)
 {
   return this->type_;
 }
 
 template <class TYPE> ACE_INLINE void
-ACE_Timer_Node_T<TYPE>::set_type (TYPE &type)
+ACE_Timer_Node_T<TYPE>::set_type (TYPE *type)
 {
   this->type_ = type;
 }

--- a/ACE/ace/Timer_Queue_T.cpp
+++ b/ACE/ace/Timer_Queue_T.cpp
@@ -13,12 +13,13 @@
 //@@ REACTOR_SPL_INCLUDE_FORWARD_DECL_ADD_HOOK
 
 #include "ace/Timer_Queue_T.h"
-#include "ace/Guard_T.h"
-#include "ace/Reverse_Lock_T.h"
-#include "ace/Log_Category.h"
-#include "ace/Null_Mutex.h"
-#include "ace/OS_NS_sys_time.h"
+
 #include "ace/Functor.h"
+#include "ace/Guard_T.h"
+#include "ace/Log_Category.h"
+#include "ace/OS_NS_sys_time.h"
+#include "ace/Reverse_Lock_T.h"
+#include "ace/Synch.h"
 
 #if !defined (__ACE_INLINE__)
 #include "ace/Timer_Queue_T.inl"
@@ -33,37 +34,131 @@ ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 #  define ACE_TIMER_SKEW 0
 #endif /* ACE_TIMER_SKEW */
 
-template <class TYPE, class FUNCTOR> ACE_INLINE
-ACE_Timer_Queue_Upcall_Base<TYPE, FUNCTOR>::ACE_Timer_Queue_Upcall_Base (FUNCTOR * upcall_functor)
-  : ACE_Abstract_Timer_Queue<TYPE>()
-  , ACE_Copy_Disabled()
-  , upcall_functor_(upcall_functor)
+template <class TQ_TYPE, class TYPE>
+ACE_Timer_Queue_Functor<TQ_TYPE, TYPE>::ACE_Timer_Queue_Functor ()
+{
+  ACE_TRACE ("ACE_Timer_Queue_Functor::ACE_Timer_Queue_Functor");
+
+}
+
+template <class TQ_TYPE, class TYPE>
+ACE_Timer_Queue_Functor<TQ_TYPE, TYPE>::~ACE_Timer_Queue_Functor ()
+{
+  ACE_TRACE ("ACE_Timer_Queue_Functor::~ACE_Timer_Queue_Functor");
+
+}
+
+template <class TQ_TYPE, class TYPE> int
+ACE_Timer_Queue_Functor<TQ_TYPE, TYPE>::registration (TQ_TYPE&,
+                                                      TYPE*,
+                                                      const void*)
+{
+  ACE_TRACE ("ACE_Timer_Queue_Functor::registration");
+
+  return 0;
+}
+
+template <class TQ_TYPE, class TYPE> int
+ACE_Timer_Queue_Functor<TQ_TYPE, TYPE>::preinvoke (TQ_TYPE&,
+                                                   TYPE*,
+                                                   const void*,
+                                                   int,
+                                                   const ACE_Time_Value&,
+                                                   const void*&)
+{
+  ACE_TRACE ("ACE_Timer_Queue_Functor::preinvoke");
+
+  return 0;
+}
+
+template <class TQ_TYPE, class TYPE> int
+ACE_Timer_Queue_Functor<TQ_TYPE, TYPE>::timeout (TQ_TYPE&,
+                                                 TYPE*,
+                                                 const void*,
+                                                 int,
+                                                 const ACE_Time_Value&)
+{
+  ACE_TRACE ("ACE_Timer_Queue_Functor::timeout");
+
+  return 0;
+}
+
+template <class TQ_TYPE, class TYPE> int
+ACE_Timer_Queue_Functor<TQ_TYPE, TYPE>::postinvoke (TQ_TYPE&,
+                                                    TYPE*,
+                                                    const void*,
+                                                    int,
+                                                    const ACE_Time_Value&,
+                                                    const void*)
+{
+  ACE_TRACE ("ACE_Timer_Queue_Functor::postinvoke");
+
+  return 0;
+}
+
+template <class TQ_TYPE, class TYPE> int
+ACE_Timer_Queue_Functor<TQ_TYPE, TYPE>::cancel_type (TQ_TYPE&,
+                                                     TYPE*,
+                                                     int,
+                                                     int&)
+{
+  ACE_TRACE ("ACE_Timer_Queue_Functor::cancel_type");
+
+  return 0;
+}
+
+template <class TQ_TYPE, class TYPE> int
+ACE_Timer_Queue_Functor<TQ_TYPE, TYPE>::cancel_timer (TQ_TYPE&,
+                                                      TYPE*,
+                                                      int,
+                                                      int)
+{
+  ACE_TRACE ("ACE_Timer_Queue_Functor::cancel_timer");
+
+  return 0;
+}
+
+template <class TQ_TYPE, class TYPE> int
+ACE_Timer_Queue_Functor<TQ_TYPE, TYPE>::deletion (TQ_TYPE&,
+                                                  TYPE*,
+                                                  const void*)
+{
+  ACE_TRACE ("ACE_Timer_Queue_Functor::deletion");
+
+  return 0;
+}
+
+template <class FUNCTOR> ACE_INLINE
+ACE_Timer_Queue_Upcall_Base<FUNCTOR>::ACE_Timer_Queue_Upcall_Base (FUNCTOR *upcall_functor)
+  : ACE_Copy_Disabled ()
+  , upcall_functor_ (upcall_functor)
   , delete_upcall_functor_ (upcall_functor == 0)
 {
   ACE_TRACE ("ACE_Timer_Queue_Upcall_Base::ACE_Timer_Queue_Upcall_Base");
 
   if (upcall_functor != 0)
-    {
-      return;
-    }
+    return;
 
-  ACE_NEW (upcall_functor_, FUNCTOR);
+  ACE_NEW (upcall_functor_,
+           FUNCTOR ());
 }
 
-template <class TYPE, class FUNCTOR> ACE_INLINE
-ACE_Timer_Queue_Upcall_Base<TYPE, FUNCTOR>::~ACE_Timer_Queue_Upcall_Base ()
+template <class FUNCTOR> ACE_INLINE
+ACE_Timer_Queue_Upcall_Base<FUNCTOR>::~ACE_Timer_Queue_Upcall_Base ()
 {
   ACE_TRACE ("ACE_Timer_Queue_Upcall_Base::~ACE_Timer_Queue_Upcall_Base");
   if (this->delete_upcall_functor_)
-    {
-      delete this->upcall_functor_;
-    }
+    delete this->upcall_functor_;
 }
 
 template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> ACE_Time_Value
-ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::gettimeofday()
+ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::gettimeofday ()
 {
-  return this->gettimeofday_static();
+  // *TODO*: add timer skew here ?
+  //ACE_Time_Value tv = this->gettimeofday_static ();
+  // tv += this->timer_skew();
+  //return tv;
+  return this->gettimeofday_static ();
 }
 
 template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> void
@@ -110,8 +205,9 @@ ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::calculate_timeout (ACE_
 }
 
 template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> ACE_Time_Value *
-ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::calculate_timeout (ACE_Time_Value *max_wait_time,
-                                                               ACE_Time_Value *the_timeout)
+ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::calculate_timeout (
+  ACE_Time_Value *max_wait_time,
+  ACE_Time_Value *the_timeout)
 {
   ACE_TRACE ("ACE_Timer_Queue_T::calculate_timeout");
 
@@ -154,14 +250,6 @@ ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::calculate_timeout (ACE_
   return the_timeout;
 }
 
-template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> ACE_Time_Value
-ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::current_time()
-{
-  ACE_Time_Value tv = this->gettimeofday_static ();
-  tv += this->timer_skew();
-  return tv;
-}
-
 template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> void
 ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::dump (void) const
 {
@@ -175,10 +263,11 @@ ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::dump (void) const
 }
 
 template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY>
-ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::ACE_Timer_Queue_T (FUNCTOR *upcall_functor,
-                                          ACE_Free_List<ACE_Timer_Node_T <TYPE> > *freelist,
-                                          TIME_POLICY const & time_policy)
-  : ACE_Timer_Queue_Upcall_Base<TYPE,FUNCTOR>(upcall_functor),
+ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::ACE_Timer_Queue_T (
+  FUNCTOR *upcall_functor,
+  ACE_Free_List<ACE_Timer_Node_T <TYPE> > *freelist,
+  TIME_POLICY const & time_policy)
+  : ACE_Timer_Queue_Upcall_Base<FUNCTOR> (upcall_functor),
     time_policy_ (time_policy),
     delete_free_list_ (freelist == 0),
     timer_skew_ (0, ACE_TIMER_SKEW)
@@ -187,7 +276,7 @@ ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::ACE_Timer_Queue_T (FUNC
 
   if (!freelist)
     ACE_NEW (free_list_,
-             (ACE_Locked_Free_List<ACE_Timer_Node_T<TYPE>,ACE_Null_Mutex>));
+             (ACE_Locked_Free_List<ACE_Timer_Node_T<TYPE>, ACE_SYNCH_NULL_MUTEX>));
   else
     free_list_ = freelist;
 }
@@ -221,16 +310,17 @@ ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::mutex (void)
 }
 
 template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> long
-ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::schedule (const TYPE &type,
-                                                      const void *act,
-                                                      const ACE_Time_Value &future_time,
-                                                      const ACE_Time_Value &interval)
+ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::schedule (
+  TYPE *handler,
+  const void *act,
+  const ACE_Time_Value &future_time,
+  const ACE_Time_Value &interval)
 {
   ACE_MT (ACE_GUARD_RETURN (ACE_LOCK, ace_mon, this->mutex_, -1));
 
   // Schedule the timer.
   long const result =
-    this->schedule_i (type,
+    this->schedule_i (handler,
                       act,
                       future_time,
                       interval);
@@ -241,7 +331,7 @@ ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::schedule (const TYPE &t
 
   // Inform upcall functor of successful registration.
   this->upcall_functor ().registration (*this,
-                                        type,
+                                        handler,
                                         act);
 
   // Return result;
@@ -299,11 +389,11 @@ ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::expire (const ACE_Time_
 }
 
 template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> void
-ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::recompute_next_abs_interval_time
-    (ACE_Timer_Node_T<TYPE> *expired,
-     const ACE_Time_Value &cur_time)
+ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::recompute_next_abs_interval_time (
+  ACE_Timer_Node_T<TYPE> *expired,
+  const ACE_Time_Value &cur_time)
 {
-  if ( expired->get_timer_value () <= cur_time )
+  if (expired->get_timer_value () <= cur_time)
     {
       /*
        * Somehow the current time is past when this time was
@@ -360,7 +450,7 @@ ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::recompute_next_abs_inte
 
 template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> int
 ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::expire_single (
-    ACE_Command_Base & pre_dispatch_command)
+    ACE_Command_Base &pre_dispatch_command)
 {
   ACE_TRACE ("ACE_Timer_Queue_T::expire_single");
   ACE_Timer_Node_Dispatch_Info_T<TYPE> info;
@@ -403,8 +493,9 @@ ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::expire_single (
 }
 
 template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> int
-ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::dispatch_info_i (const ACE_Time_Value &cur_time,
-                                                             ACE_Timer_Node_Dispatch_Info_T<TYPE> &info)
+ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::dispatch_info_i (
+  const ACE_Time_Value &cur_time,
+  ACE_Timer_Node_Dispatch_Info_T<TYPE> &info)
 {
   ACE_TRACE ("ACE_Timer_Queue_T::dispatch_info_i");
 
@@ -444,7 +535,8 @@ ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::dispatch_info_i (const 
 }
 
 template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> void
-ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::return_node (ACE_Timer_Node_T<TYPE> *node)
+ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::return_node (
+  ACE_Timer_Node_T<TYPE> *node)
 {
   ACE_MT (ACE_GUARD (ACE_LOCK, ace_mon, this->mutex_));
   this->free_node (node);

--- a/ACE/ace/Timer_Queue_T.h
+++ b/ACE/ace/Timer_Queue_T.h
@@ -20,13 +20,82 @@
 # pragma once
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
-#include "ace/Time_Value.h"
 #include "ace/Abstract_Timer_Queue.h"
+#include "ace/Copy_Disabled.h"
+#include "ace/Synch_Traits.h"
 #include "ace/Timer_Queue_Iterator.h"
 #include "ace/Time_Policy.h"
-#include "ace/Copy_Disabled.h"
+#include "ace/Time_Value.h"
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
+
+/**
+  * @class ACE_Timer_Queue_Functor
+  *
+  * @brief Functor for timer queues.
+  *
+  * This class defines the functor base-class required by a timer
+  * queue to call <handle_timeout> on event handlers.
+  * Note that polymorphism isn't currently used for performance
+  * reasons (FUNCTORs are implemented as type traits for now, see below)
+  */
+template <class TQ_TYPE, class TYPE>
+class ACE_Timer_Queue_Functor
+{
+public:
+  // = Initialization and termination methods.
+  /// Constructor.
+  ACE_Timer_Queue_Functor (void);
+  
+  /// Destructor.
+  virtual ~ACE_Timer_Queue_Functor (void);
+
+  /// This method is called when a timer is registered.
+  int registration (TQ_TYPE &timer_queue,
+                    TYPE *handler,
+                    const void *arg);
+  
+  /// This method is called before the timer expires.
+  int preinvoke (TQ_TYPE &timer_queue,
+                 TYPE *handler,
+                 const void *arg,
+                 int recurring_timer,
+                 const ACE_Time_Value &cur_time,
+                 const void *&upcall_act);
+  
+  /// This method is called when the timer expires.
+  int timeout (TQ_TYPE &timer_queue,
+               TYPE *handler,
+               const void *arg,
+               int recurring_timer,
+               const ACE_Time_Value &cur_time);
+
+  /// This method is called after the timer expires.
+  int postinvoke (TQ_TYPE &timer_queue,
+                  TYPE *handler,
+                  const void *arg,
+                  int recurring_timer,
+                  const ACE_Time_Value &cur_time,
+                  const void *upcall_act);
+  
+  /// This method is called when a handler is cancelled
+  int cancel_type (TQ_TYPE &timer_queue,
+                   TYPE *handler,
+                   int dont_call,
+                   int &requires_reference_counting);
+
+  /// This method is called when a timer is cancelled
+  int cancel_timer (TQ_TYPE &timer_queue,
+                    TYPE *handler,
+                    int dont_call,
+                    int requires_reference_counting);
+
+  /// This method is called when the timer queue is destroyed and
+  /// the timer is still contained in it
+  int deletion (TQ_TYPE &timer_queue,
+                TYPE *handler,
+                const void *arg);
+};
 
 /**
  * @class ACE_Timer_Queue_Upcall_Base
@@ -36,20 +105,27 @@ ACE_BEGIN_VERSIONED_NAMESPACE_DECL
  * namely the ACE_Proactor needs to set a backpointer in the upcall
  * functor.
  */
-template<typename TYPE, typename FUNCTOR>
+template <typename FUNCTOR>
 class ACE_Timer_Queue_Upcall_Base
-  : public ACE_Abstract_Timer_Queue<TYPE>
-  , private ACE_Copy_Disabled
+ : private ACE_Copy_Disabled
 {
 public:
   // Constructor
-  explicit ACE_Timer_Queue_Upcall_Base(FUNCTOR * upcall_functor = 0);
+  explicit ACE_Timer_Queue_Upcall_Base (FUNCTOR *upcall_functor = 0);
 
   /// Destructor
   virtual ~ACE_Timer_Queue_Upcall_Base (void);
 
   /// Accessor to the upcall functor
   FUNCTOR & upcall_functor (void);
+
+  /// Setter to the upcall functor
+  void upcall_functor (FUNCTOR *upcall_functor,
+                       bool delete_upcall_functor = false);
+  
+  /// Make default upcall functor
+  /// Note: return value needs to be freed !
+  static FUNCTOR *make_functor (void);
 
 protected:
   /// Upcall functor
@@ -70,7 +146,8 @@ protected:
  */
 template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY = ACE_Default_Time_Policy>
 class ACE_Timer_Queue_T
-  : public ACE_Timer_Queue_Upcall_Base<TYPE,FUNCTOR>
+ : public ACE_Abstract_Timer_Queue<TYPE>
+ , public ACE_Timer_Queue_Upcall_Base<FUNCTOR>
 {
 public:
   // = Initialization and termination methods.
@@ -81,8 +158,8 @@ public:
    * timer nodes.  If 0, then a default freelist will be created.
    */
   ACE_Timer_Queue_T (FUNCTOR *upcall_functor = 0,
-                    ACE_Free_List<ACE_Timer_Node_T <TYPE> > *freelist = 0,
-                    TIME_POLICY const & time_policy = TIME_POLICY());
+                     ACE_Free_List<ACE_Timer_Node_T<TYPE> > *freelist = 0,
+                     TIME_POLICY const & time_policy = TIME_POLICY ());
 
   /// Destructor - make virtual for proper destruction of inherited
   /// classes.
@@ -92,7 +169,7 @@ public:
    * Implement ACE_Abstract_Timer_Queue<TYPE>::schedule () with the right
    * locking strategy.
    */
-  virtual long schedule (const TYPE &type,
+  virtual long schedule (TYPE *type,
                          const void *act,
                          const ACE_Time_Value &future_time,
                          const ACE_Time_Value &interval = ACE_Time_Value::zero);
@@ -104,7 +181,7 @@ public:
    */
   virtual int expire (const ACE_Time_Value &current_time);
   virtual int expire (void);
-  virtual int expire_single(ACE_Command_Base & pre_dispatch_command);
+  virtual int expire_single (ACE_Command_Base &pre_dispatch_command);
   //@}
 
   /**
@@ -132,14 +209,12 @@ public:
    */
   virtual void gettimeofday (ACE_Time_Value (*gettimeofday)(void));
 
-  /// Implement an inlined, non-abstract version of gettimeofday(),
-  /// through this  member function the internals of the class can
-  /// make calls to  ACE_OS::gettimeofday() with zero overhead.
-  ACE_Time_Value gettimeofday_static();
+  /// Retrieve the current time of day (according to the TIME_POLICY).
+  ACE_Time_Value gettimeofday_static ();
 
   /// Allows applications to control how the timer queue gets the time
   /// of day.
-  void set_time_policy(TIME_POLICY const & time_policy);
+  void set_time_policy (TIME_POLICY const & time_policy);
 
   /// Determine the next event to timeout.  Returns @a max if there are
   /// no pending timers or if all pending timers are longer than max.
@@ -151,7 +226,6 @@ public:
   virtual ACE_Time_Value *calculate_timeout (ACE_Time_Value *max);
   virtual ACE_Time_Value *calculate_timeout (ACE_Time_Value *max,
                                              ACE_Time_Value *the_timeout);
-  virtual ACE_Time_Value current_time();
   //@}
 
   /// Set the timer skew for the Timer_Queue.
@@ -185,9 +259,8 @@ public:
                    const void *upcall_act);
 
 protected:
-
   /// Schedule a timer.
-  virtual long schedule_i (const TYPE &type,
+  virtual long schedule_i (TYPE *handler,
                            const void *act,
                            const ACE_Time_Value &future_time,
                            const ACE_Time_Value &interval) = 0;

--- a/ACE/ace/Timer_Queue_T.inl
+++ b/ACE/ace/Timer_Queue_T.inl
@@ -1,14 +1,37 @@
 // -*- C++ -*-
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
-template <class TYPE, class FUNCTOR> ACE_INLINE FUNCTOR &
-ACE_Timer_Queue_Upcall_Base<TYPE, FUNCTOR>::upcall_functor (void)
+template <class FUNCTOR> ACE_INLINE FUNCTOR &
+ACE_Timer_Queue_Upcall_Base<FUNCTOR>::upcall_functor (void)
 {
   return *this->upcall_functor_;
 }
 
+template <class FUNCTOR> ACE_INLINE void
+ACE_Timer_Queue_Upcall_Base<FUNCTOR>::upcall_functor (
+  FUNCTOR *upcall_functor,
+  bool delete_upcall_functor)
+{
+  if (delete_upcall_functor_)
+    delete upcall_functor_;
+  
+  upcall_functor_ = upcall_functor;
+  delete_upcall_functor_ = (upcall_functor && delete_upcall_functor);
+}
+
+template <class FUNCTOR> ACE_INLINE FUNCTOR *
+ACE_Timer_Queue_Upcall_Base<FUNCTOR>::make_functor ()
+{
+  FUNCTOR* functor = 0;
+  ACE_NEW_NORETURN (functor,
+                    FUNCTOR ());
+  
+  return functor;
+}
+
 template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> ACE_INLINE void
-ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::timer_skew (const ACE_Time_Value &skew)
+ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::timer_skew (
+  const ACE_Time_Value &skew)
 {
   timer_skew_ = skew;
 }
@@ -20,8 +43,9 @@ ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::timer_skew (void) const
 }
 
 template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> int
-ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::dispatch_info (const ACE_Time_Value &cur_time,
-                                                           ACE_Timer_Node_Dispatch_Info_T<TYPE> &info)
+ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::dispatch_info (
+  const ACE_Time_Value &cur_time,
+  ACE_Timer_Node_Dispatch_Info_T<TYPE> &info)
 {
   ACE_TRACE ("ACE_Timer_Queue_T::dispatch_info");
   ACE_MT (ACE_GUARD_RETURN (ACE_LOCK, ace_mon, this->mutex_, 0));
@@ -30,8 +54,9 @@ ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::dispatch_info (const AC
 }
 
 template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> ACE_INLINE void
-ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::upcall (ACE_Timer_Node_Dispatch_Info_T<TYPE> &info,
-                                                    const ACE_Time_Value &cur_time)
+ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::upcall (
+  ACE_Timer_Node_Dispatch_Info_T<TYPE> &info,
+  const ACE_Time_Value &cur_time)
 {
   this->upcall_functor ().timeout (*this,
                                    info.type_,
@@ -41,9 +66,10 @@ ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::upcall (ACE_Timer_Node_
 }
 
 template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> ACE_INLINE void
-ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::preinvoke (ACE_Timer_Node_Dispatch_Info_T<TYPE> &info,
-                                                       const ACE_Time_Value &cur_time,
-                                                       const void *&upcall_act)
+ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::preinvoke (
+  ACE_Timer_Node_Dispatch_Info_T<TYPE> &info,
+  const ACE_Time_Value &cur_time,
+  const void *&upcall_act)
 {
   this->upcall_functor ().preinvoke (*this,
                                      info.type_,
@@ -54,9 +80,10 @@ ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::preinvoke (ACE_Timer_No
 }
 
 template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> ACE_INLINE void
-ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::postinvoke (ACE_Timer_Node_Dispatch_Info_T<TYPE> &info,
-                                                        const ACE_Time_Value &cur_time,
-                                                        const void *upcall_act)
+ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::postinvoke (
+  ACE_Timer_Node_Dispatch_Info_T<TYPE> &info,
+  const ACE_Time_Value &cur_time,
+  const void *upcall_act)
 {
   this->upcall_functor ().postinvoke (*this,
                                       info.type_,
@@ -74,7 +101,8 @@ ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::gettimeofday_static (vo
 }
 
 template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY> ACE_INLINE void
-ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::set_time_policy (TIME_POLICY const & rhs)
+ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>::set_time_policy (
+  TIME_POLICY const &rhs)
 {
   this->time_policy_ = rhs;
 }

--- a/ACE/ace/Timer_Queuefwd.h
+++ b/ACE/ace/Timer_Queuefwd.h
@@ -15,13 +15,13 @@
 
 #include /**/ "ace/pre.h"
 
-#include "ace/config-all.h"
+#include "ace/config-lite.h"
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
 class ACE_Event_Handler;
 template <class TYPE> class ACE_Abstract_Timer_Queue;
-typedef ACE_Abstract_Timer_Queue<ACE_Event_Handler*> ACE_Timer_Queue;
+typedef ACE_Abstract_Timer_Queue<ACE_Event_Handler> ACE_Timer_Queue;
 
 ACE_END_VERSIONED_NAMESPACE_DECL
 

--- a/ACE/ace/Timer_Wheel.h
+++ b/ACE/ace/Timer_Wheel.h
@@ -13,8 +13,10 @@
 #define ACE_TIMER_WHEEL_H
 #include /**/ "ace/pre.h"
 
-#include "ace/Timer_Wheel_T.h"
+#include "ace/Event_Handler.h"
 #include "ace/Event_Handler_Handle_Timeout_Upcall.h"
+#include "ace/Synch_Traits.h"
+#include "ace/Timer_Wheel_T.h"
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 # pragma once
@@ -25,12 +27,13 @@ ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 // The following typedefs are here for ease of use and backward
 // compatibility.
 
-typedef ACE_Timer_Wheel_T<ACE_Event_Handler *,
+typedef ACE_Timer_Wheel_T<ACE_Event_Handler,
                          ACE_Event_Handler_Handle_Timeout_Upcall,
-                         ACE_SYNCH_RECURSIVE_MUTEX>
+                         ACE_SYNCH_RECURSIVE_MUTEX,
+                         ACE_Default_Time_Policy>
         ACE_Timer_Wheel;
 
-typedef ACE_Timer_Wheel_Iterator_T<ACE_Event_Handler *,
+typedef ACE_Timer_Wheel_Iterator_T<ACE_Event_Handler,
                                    ACE_Event_Handler_Handle_Timeout_Upcall,
                                    ACE_SYNCH_RECURSIVE_MUTEX,
                                    ACE_Default_Time_Policy>

--- a/ACE/ace/Timer_Wheel_T.h
+++ b/ACE/ace/Timer_Wheel_T.h
@@ -22,7 +22,7 @@
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 
 // Forward declaration
-template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY>
+template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY = ACE_Default_Time_Policy>
 class ACE_Timer_Wheel_T;
 
 /**
@@ -87,23 +87,25 @@ private:
  * Timer Facilities"
  * (http://dworkin.wustl.edu/~varghese/PAPERS/newbsd.ps.Z)
  */
-template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY = ACE_Default_Time_Policy>
+template <class TYPE, class FUNCTOR, class ACE_LOCK, typename TIME_POLICY>
 class ACE_Timer_Wheel_T
   : public ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>
 {
 public:
   /// Type of iterator
-  typedef ACE_Timer_Wheel_Iterator_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY> Iterator;
+  typedef ACE_Timer_Wheel_Iterator_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY> ITERATOR_T;
+
   /// Iterator is a friend
   friend class ACE_Timer_Wheel_Iterator_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY>;
+
   typedef ACE_Timer_Node_T<TYPE> Node;
   /// Type inherited from
-  typedef ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY> Base_Timer_Queue;
+  typedef ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY> TIMER_QUEUE_T;
   typedef ACE_Free_List<Node> FreeList;
 
   /// Default constructor
   ACE_Timer_Wheel_T (FUNCTOR* upcall_functor = 0, FreeList* freelist = 0,
-                     TIME_POLICY const & time_policy = TIME_POLICY());
+                     TIME_POLICY const & time_policy = TIME_POLICY ());
 
   /// Constructor with opportunities to set the wheelsize and resolution
   ACE_Timer_Wheel_T (u_int spoke_count,
@@ -111,7 +113,7 @@ public:
                      size_t prealloc = 0,
                      FUNCTOR* upcall_functor = 0,
                      FreeList* freelist = 0,
-                     TIME_POLICY const & time_policy = TIME_POLICY());
+                     TIME_POLICY const & time_policy = TIME_POLICY ());
 
   /// Destructor
   virtual ~ACE_Timer_Wheel_T (void);
@@ -128,11 +130,11 @@ public:
   virtual int reset_interval (long timer_id,
                               const ACE_Time_Value& interval);
 
-  /// Cancel all timer associated with @a type.  If @a dont_call_handle_close is
+  /// Cancel all timer associated with @a type.  If @a dont_call is
   /// 0 then the <functor> will be invoked.  Returns number of timers
   /// cancelled.
-  virtual int cancel (const TYPE& type,
-                      int dont_call_handle_close = 1);
+  virtual int cancel (TYPE *handler,
+                      int dont_call = 1);
 
   // Cancel a timer, storing the magic cookie in act (if nonzero).
   // Calls the functor if dont_call_handle_close is 0 and returns 1
@@ -169,27 +171,28 @@ public:
   virtual ACE_Timer_Node_T<TYPE>* get_first (void);
 
 protected:
-
   /// Schedules a timer.
-  virtual long schedule_i (const TYPE& type,
+  virtual long schedule_i (TYPE *handler,
                            const void* act,
                            const ACE_Time_Value& future_time,
                            const ACE_Time_Value& interval);
 
 private:
+  typedef ACE_Timer_Queue_T<TYPE, FUNCTOR, ACE_LOCK, TIME_POLICY> inherited;
+
   // The following are documented in the .cpp file.
   ACE_Timer_Node_T<TYPE>* get_first_i (void) const;
   ACE_Timer_Node_T<TYPE>* remove_first_expired (const ACE_Time_Value& now);
   void open_i (size_t prealloc, u_int spokes, u_int res);
   virtual void reschedule (ACE_Timer_Node_T<TYPE> *);
-  ACE_Timer_Node_T<TYPE>* find_spoke_node(u_int spoke, long timer_id) const;
-  ACE_Timer_Node_T<TYPE>* find_node(long timer_id) const;
-  u_int calculate_spoke(const ACE_Time_Value& expire) const;
-  long generate_timer_id(u_int spoke);
+  ACE_Timer_Node_T<TYPE>* find_spoke_node (u_int spoke, long timer_id) const;
+  ACE_Timer_Node_T<TYPE>* find_node (long timer_id) const;
+  u_int calculate_spoke (const ACE_Time_Value& expire) const;
+  long generate_timer_id (u_int spoke);
   void schedule_i (ACE_Timer_Node_T<TYPE>* n, u_int spoke, const ACE_Time_Value& expire);
   void cancel_i (ACE_Timer_Node_T<TYPE>* n);
   void unlink (ACE_Timer_Node_T<TYPE>* n);
-  void recalc_earliest(const ACE_Time_Value& last);
+  void recalc_earliest (const ACE_Time_Value& last);
 
 private:
   int power2bits (int n, int min_bits, int max_bits);
@@ -207,7 +210,7 @@ private:
   /// Index of the list with the earliest time
   u_int earliest_spoke_;
   /// Iterator used to expire timers.
-  Iterator* iterator_;
+  ITERATOR_T* iterator_;
   /// The total amount of time in one iteration of the wheel. (resolution * spoke_count)
   ACE_Time_Value wheel_time_;
   /// The total number of timers currently scheduled.

--- a/ACE/ace/WFMO_Reactor.cpp
+++ b/ACE/ace/WFMO_Reactor.cpp
@@ -1,3 +1,4 @@
+#include "ace/Synch.h"
 #include "ace/WFMO_Reactor.h"
 
 #if defined (ACE_WIN32)
@@ -6,7 +7,6 @@
 #include "ace/Timer_Heap.h"
 #include "ace/Thread.h"
 #include "ace/OS_NS_errno.h"
-#include "ace/Null_Condition.h"
 
 #if !defined (__ACE_INLINE__)
 #include "ace/WFMO_Reactor.inl"

--- a/ACE/ace/WIN32_Asynch_IO.cpp
+++ b/ACE/ace/WIN32_Asynch_IO.cpp
@@ -1,3 +1,4 @@
+#include "ace/Synch.h"
 #include "ace/WIN32_Asynch_IO.h"
 
 #if defined (ACE_HAS_WIN32_OVERLAPPED_IO) && \

--- a/ACE/ace/WIN32_Asynch_IO.cpp
+++ b/ACE/ace/WIN32_Asynch_IO.cpp
@@ -175,7 +175,12 @@ ACE_WIN32_Asynch_Operation::cancel (void)
 
   // @@ This API returns 0 on failure. So, I am returning -1 in that
   //    case. Is that right? (Alex).
+#if (_WIN32_WINNT < 0x0600)
   int const result = (int) ::CancelIo (this->handle_);
+#else
+  int const result = (int) ::CancelIoEx (this->handle_,
+                                         NULL);
+#endif /* _WIN32_WINNT < 0x0600 */
 
   if (result == 0)
     // Couldn't cancel the operations.

--- a/ACE/ace/WIN32_Asynch_IO.cpp
+++ b/ACE/ace/WIN32_Asynch_IO.cpp
@@ -179,7 +179,7 @@ ACE_WIN32_Asynch_Operation::cancel (void)
   int const result = (int) ::CancelIo (this->handle_);
 #else
   int const result = (int) ::CancelIoEx (this->handle_,
-                                         NULL);
+                                         0);
 #endif /* _WIN32_WINNT < 0x0600 */
 
   if (result == 0)

--- a/ACE/ace/WIN32_Proactor.cpp
+++ b/ACE/ace/WIN32_Proactor.cpp
@@ -1,5 +1,4 @@
-//
-
+#include "ace/Synch.h"
 #include "ace/WIN32_Proactor.h"
 
 #if defined (ACE_WIN32) && defined (ACE_HAS_WIN32_OVERLAPPED_IO)

--- a/ACE/ace/WIN32_Proactor.cpp
+++ b/ACE/ace/WIN32_Proactor.cpp
@@ -636,6 +636,12 @@ ACE_WIN32_Proactor::application_specific_code (ACE_WIN32_Asynch_Result *asynch_r
                                                const void *completion_key,
                                                u_long error)
 {
+  // *NOTE*: on Win32 with MSVC (ACE_HAS_WIN32_STRUCTURAL_EXCEPTIONS set), this
+  //         needs to be compiled with '/EHa' to work properly, otherwise
+  //         'finally' is skipped, leaking memory
+  // *TODO*: the default (auto-)generated MPC MSVC project files do not enforce
+  //         this (uses '/EHsc', see $MPC_ROOT/templates/nmakedll.mpt:36)
+  // *WORKAROUND*: #undef(ine) ACE_HAS_WIN32_STRUCTURAL_EXCEPTIONS in config.h
   ACE_SEH_TRY
     {
       // Call completion hook

--- a/ACE/ace/ace.mpc
+++ b/ACE/ace/ace.mpc
@@ -3,6 +3,12 @@ project(ACE) : ace_output, acedefaults, install, other, codecs, token, svcconf, 
   avoids       = ace_for_tao
   sharedname   = ACE
   dynamicflags += ACE_BUILD_DLL
+// *NOTE*: this is the proposed solution for issues with structured exceptions
+//         on Win32
+  specific(prop:microsoft) {
+      compile_flags -= /EHsc
+      compile_flags += /EHa
+  }
 
   Source_Files(ACE_COMPONENTS) {
     ACE.cpp

--- a/ACE/ace/ace.mpc
+++ b/ACE/ace/ace.mpc
@@ -3,10 +3,6 @@ project(ACE) : ace_output, acedefaults, install, other, codecs, token, svcconf, 
   avoids       = ace_for_tao
   sharedname   = ACE
   dynamicflags += ACE_BUILD_DLL
-//  specific(prop:microsoft) {
-//      compile_flags -= /EHsc
-//      compile_flags += /EHa
-//  }
 
   Source_Files(ACE_COMPONENTS) {
     ACE.cpp

--- a/ACE/ace/ace.mpc
+++ b/ACE/ace/ace.mpc
@@ -3,6 +3,10 @@ project(ACE) : ace_output, acedefaults, install, other, codecs, token, svcconf, 
   avoids       = ace_for_tao
   sharedname   = ACE
   dynamicflags += ACE_BUILD_DLL
+//  specific(prop:microsoft) {
+//      compile_flags -= /EHsc
+//      compile_flags += /EHa
+//  }
 
   Source_Files(ACE_COMPONENTS) {
     ACE.cpp
@@ -382,7 +386,9 @@ project(ACE) : ace_output, acedefaults, install, other, codecs, token, svcconf, 
 
   Inline_Files {
     Bound_Ptr.inl
+    Condition_Recursive_Thread_Mutex.inl
     Condition_T.inl
+    Condition_Thread_Mutex.inl
     Guard_T.inl
     Handle_Gobbler.inl
     Intrusive_Auto_Ptr.inl
@@ -392,6 +398,7 @@ project(ACE) : ace_output, acedefaults, install, other, codecs, token, svcconf, 
     Reverse_Lock_T.inl
     TSS_T.inl
     Time_Value_T.inl
+    Timer_Queue_Adapters.inl
   }
 
   Header_Files {
@@ -404,7 +411,9 @@ project(ACE) : ace_output, acedefaults, install, other, codecs, token, svcconf, 
     Codeset_Symbols.h
     CORBA_macros.h
     Codeset_Symbols.h
+    Condition_Recursive_Thread_Mutex.h
     Condition_T.h
+    Condition_Thread_Mutex.h
     Countdown_Time.h
     Default_Constants.h
     Event_Base.h
@@ -459,6 +468,7 @@ project(ACE) : ace_output, acedefaults, install, other, codecs, token, svcconf, 
     Timer_Heap.h
     Timer_List.h
     Timer_Queue.h
+    Timer_Queue_Adapters.h
     Timer_Queuefwd.h
     Timer_Wheel.h
     Truncate.h

--- a/ACE/ace/config-g++-common.h
+++ b/ACE/ace/config-g++-common.h
@@ -50,7 +50,7 @@
 // *NOTE*: suppress a warning, g++ 5.2.1 does not support attributes on template
 // instantiation declarations
 // *TODO*: this probably goes back further than 5.2
-# if (__GNUC__ >= 5 || (__GNUC__ == 5 && __GNUC_MINOR__ >= 2))
+# if (__GNUC__ >= 6 || (__GNUC__ == 5 && __GNUC_MINOR__ >= 2))
 #  define ACE_LACKS_CPP11_EXTERN_TEMPLATE_ATTRIBUTES
 # endif /* __GNUC__ >= 5.2 */
 #endif /* ACE_HAS_CPP11 */

--- a/ACE/ace/config-g++-common.h
+++ b/ACE/ace/config-g++-common.h
@@ -46,6 +46,13 @@
 # if (__GNUC__ >= 5 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3))
 #  define ACE_HAS_CPP11_EXTERN_TEMPLATES
 # endif /* __GNUC__ >= 4.3 */
+
+// *NOTE*: suppress a warning, g++ 5.2.1 does not support attributes on template
+// instantiation declarations
+// *TODO*: this probably goes back further than 5.2
+# if (__GNUC__ >= 5 || (__GNUC__ == 5 && __GNUC_MINOR__ >= 2))
+#  define ACE_LACKS_CPP11_EXTERN_TEMPLATE_ATTRIBUTES
+# endif /* __GNUC__ >= 5.2 */
 #endif /* ACE_HAS_CPP11 */
 
 #if (defined (i386) || defined (__i386__)) && !defined (ACE_SIZEOF_LONG_DOUBLE)

--- a/ACE/ace/config-g++-common.h
+++ b/ACE/ace/config-g++-common.h
@@ -38,7 +38,15 @@
 # if __cplusplus > 201103L
 #  define ACE_HAS_CPP14
 # endif
-#endif
+#endif /* __GNUC__ >= 4.7 */
+
+// *NOTE*: this feature may go back further, see e.g.:
+//         https://gcc.gnu.org/projects/cxx0x.html
+#if defined (ACE_HAS_CPP11)
+# if (__GNUC__ >= 5 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3))
+#  define ACE_HAS_CPP11_EXTERN_TEMPLATES
+# endif /* __GNUC__ >= 4.3 */
+#endif /* ACE_HAS_CPP11 */
 
 #if (defined (i386) || defined (__i386__)) && !defined (ACE_SIZEOF_LONG_DOUBLE)
 # define ACE_SIZEOF_LONG_DOUBLE 12

--- a/ACE/ace/config-macros.h
+++ b/ACE/ace/config-macros.h
@@ -49,7 +49,11 @@
 # if defined (ACE_LACKS_IOSTREAM_TOTALLY)
 #   define ACE_OSTREAM_TYPE FILE
 # else  /* ! ACE_LACKS_IOSTREAM_TOTALLY */
+#  if defined ACE_USES_STD_NAMESPACE_FOR_STDCPP_LIB
+#   define ACE_OSTREAM_TYPE std::ostream
+#  else
 #   define ACE_OSTREAM_TYPE ostream
+#  endif /* ! ACE_USES_STD_NAMESPACE_FOR_STDCPP_LIB */
 # endif /* ! ACE_LACKS_IOSTREAM_TOTALLY */
 #endif /* ! ACE_OSTREAM_TYPE */
 

--- a/ACE/ace/config-sunos5.11.h
+++ b/ACE/ace/config-sunos5.11.h
@@ -10,4 +10,7 @@
 // #include the SunOS 5.10 config, then add any SunOS 5.11 updates below.
 #include "ace/config-sunos5.10.h"
 
+// *TODO*: find out how far this also hold for previous solaris releases
+#define ACE_HAS_SOLARIS11_GETPWNAM_R
+
 #endif /* ACE_CONFIG_H */

--- a/ACE/ace/config-win32-msvc-14.h
+++ b/ACE/ace/config-win32-msvc-14.h
@@ -41,6 +41,10 @@
 // Visual Studio 2015 has adequate C++11 support
 #define ACE_HAS_CPP11
 
+// *TODO*: this C++11-feature goes back further (at least to MSVC 2010), see:
+//         https://msdn.microsoft.com/en-us/library/hh567368.aspx#featurelist
+#define ACE_HAS_CPP11_EXTERN_TEMPLATES
+
 #define ACE_PUTENV_EQUIVALENT ::_putenv
 #define ACE_TEMPNAM_EQUIVALENT ::_tempnam
 #define ACE_STRDUP_EQUIVALENT ::_strdup

--- a/ACE/apps/JAWS3/http/HTTP_Service_Handler.h
+++ b/ACE/apps/JAWS3/http/HTTP_Service_Handler.h
@@ -2,10 +2,10 @@
 #ifndef JAWS_HTTP_SERVICE_HANDLER_H
 #define JAWS_HTTP_SERVICE_HANDLER_H
 
-#include "ace/Synch.h"
 #include "ace/Acceptor.h"
-#include "ace/Svc_Handler.h"
 #include "ace/SOCK_Acceptor.h"
+#include "ace/Svc_Handler.h"
+#include "ace/Synch_Traits.h"
 
 #include "jaws3/Protocol_Handler.h"
 

--- a/ACE/apps/JAWS3/jaws3/Cached_Allocator_T.h
+++ b/ACE/apps/JAWS3/jaws3/Cached_Allocator_T.h
@@ -3,9 +3,9 @@
 #define JAWS_CACHED_ALLOCATOR_T_H
 
 #include "ace/ACE.h"
-#include "ace/Synch.h"
-#include "ace/Malloc.h"
 #include "ace/Free_List.h"
+#include "ace/Malloc.h"
+#include "ace/Synch_Traits.h"
 
 #define JAWS_DEFAULT_ALLOCATOR_CHUNKS 10
 #define JAWS_CACHED_ALLOCATOR(T) \

--- a/ACE/apps/JAWS3/jaws3/Config_File.cpp
+++ b/ACE/apps/JAWS3/jaws3/Config_File.cpp
@@ -1,8 +1,9 @@
-#include "ace/OS_NS_stdlib.h"
-#include "ace/OS_NS_string.h"
 #include "ace/FILE_Connector.h"
 #include "ace/Message_Block.h"
+#include "ace/OS_NS_stdlib.h"
+#include "ace/OS_NS_string.h"
 #include "ace/Singleton.h"
+#include "ace/Synch.h"
 #include "ace/Unbounded_Queue.h"
 
 #ifndef JAWS_BUILD_DLL

--- a/ACE/apps/JAWS3/jaws3/Datagram.h
+++ b/ACE/apps/JAWS3/jaws3/Datagram.h
@@ -3,9 +3,9 @@
 #define JAWS_DATAGRAM_H
 
 #include "ace/Addr.h"
-#include "ace/Synch.h"
 #include "ace/Singleton.h"
 #include "ace/SOCK_Dgram.h"
+#include "ace/Synch_Traits.h"
 
 #include "jaws3/Export.h"
 #include "jaws3/Event_Completer.h"

--- a/ACE/apps/JAWS3/jaws3/Options.h
+++ b/ACE/apps/JAWS3/jaws3/Options.h
@@ -3,7 +3,7 @@
 #define JAWS_OPTIONS_H
 
 #include "ace/Singleton.h"
-#include "ace/Synch.h"
+#include "ace/Synch_Traits.h"
 
 #include "jaws3/Export.h"
 #include "jaws3/Config_File.h"

--- a/ACE/apps/JAWS3/jaws3/Signal_Task.h
+++ b/ACE/apps/JAWS3/jaws3/Signal_Task.h
@@ -2,9 +2,9 @@
 #ifndef JAWS_SIGNAL_TASK_H
 #define JAWS_SIGNAL_TASK_H
 
-#include "ace/Synch.h"
 #include "ace/Signal.h"
 #include "ace/Singleton.h"
+#include "ace/Synch_Traits.h"
 
 #include "jaws3/Export.h"
 

--- a/ACE/apps/JAWS3/jaws3/Symbol_Table.cpp
+++ b/ACE/apps/JAWS3/jaws3/Symbol_Table.cpp
@@ -2,6 +2,8 @@
 #define JAWS_BUILD_DLL
 #endif
 
+#include "ace/Synch.h"
+
 #include "jaws3/Symbol_Table.h"
 
 JAWS_Symbol_Table::JAWS_Symbol_Table (size_t size)

--- a/ACE/apps/JAWS3/jaws3/Symbol_Table.h
+++ b/ACE/apps/JAWS3/jaws3/Symbol_Table.h
@@ -3,7 +3,7 @@
 #define JAWS_SYMBOL_TABLE_H
 
 #include "ace/Hash_Map_Manager.h"
-#include "ace/Synch.h"
+#include "ace/Synch_Traits.h"
 
 #include "jaws3/Export.h"
 

--- a/ACE/apps/JAWS3/small/SS_Service_Handler.h
+++ b/ACE/apps/JAWS3/small/SS_Service_Handler.h
@@ -2,11 +2,11 @@
 #ifndef TERA_SS_SERVICE_HANDLER_H
 #define TERA_SS_SERVICE_HANDLER_H
 
-#include "ace/Synch.h"
 #include "ace/Acceptor.h"
-#include "ace/Svc_Handler.h"
 #include "ace/SOCK_Acceptor.h"
 #include "ace/svc_export.h"
+#include "ace/Svc_Handler.h"
+#include "ace/Synch_Traits.h"
 
 #include "jaws3/Protocol_Handler.h"
 

--- a/ACE/examples/APG/Logging/LogManager.h
+++ b/ACE/examples/APG/Logging/LogManager.h
@@ -1,8 +1,9 @@
 #include "ace/streams.h"
-#include "ace/Synch.h"
-#include "ace/Singleton.h"
+
 #include "ace/Log_Msg.h"
 #include "ace/Log_Msg_Callback.h"
+#include "ace/Singleton.h"
+#include "ace/Synch_Traits.h"
 
 #ifndef LOG_MANAGER_H
 #define LOG_MANAGER_H
@@ -92,7 +93,7 @@ LogManager::redirectToCallback (ACE_Log_Msg_Callback * callback)
 // Listing 2
 
 // Listing 3 code/ch03
-typedef ACE_Singleton<LogManager, ACE_Null_Mutex>
+typedef ACE_Singleton<LogManager, ACE_SYNCH_NULL_MUTEX>
         LogManagerSingleton;
 #define LOG_MANAGER LogManagerSingleton::instance()
 // Listing 3

--- a/ACE/examples/APG/Logging/Use_LogManager.cpp
+++ b/ACE/examples/APG/Logging/Use_LogManager.cpp
@@ -1,3 +1,6 @@
+
+#include "ace/Synch.h"
+
 #include "LogManager.h"
 
 // Listing 1 code/ch03

--- a/ACE/examples/APG/ThreadPools/Futures.cpp
+++ b/ACE/examples/APG/ThreadPools/Futures.cpp
@@ -12,6 +12,9 @@
 #include "ace/Activation_Queue.h"
 #include "ace/Condition_T.h"
 
+// *NOTE*: explicit template instantiation required here...
+template class ACE_Condition<ACE_Recursive_Thread_Mutex>;
+
 #define OUTSTANDING_REQUESTS 20
 
 // Listing 2 code/ch16

--- a/ACE/examples/APG/ThreadPools/Futures.cpp
+++ b/ACE/examples/APG/ThreadPools/Futures.cpp
@@ -12,9 +12,6 @@
 #include "ace/Activation_Queue.h"
 #include "ace/Condition_T.h"
 
-// *NOTE*: explicit template instantiation required here...
-template class ACE_Condition<ACE_Recursive_Thread_Mutex>;
-
 #define OUTSTANDING_REQUESTS 20
 
 // Listing 2 code/ch16

--- a/ACE/examples/APG/ThreadSafety/ClientContext.h
+++ b/ACE/examples/APG/ThreadSafety/ClientContext.h
@@ -7,9 +7,9 @@
 #define __CLIENTCONTEXT_H_
 
 #include "ace/Hash_Map_Manager.h"
-#include "ace/Synch.h"
+#include "ace/Synch_Traits.h"
 
-typedef ACE_Hash_Map_Manager<const char *, void *, ACE_Null_Mutex>
+typedef ACE_Hash_Map_Manager<const char *, void *, ACE_SYNCH_NULL_MUTEX>
 Map;
 
 // Listing 1 code/ch14

--- a/ACE/examples/APG/Threads/Message_Receiver.h
+++ b/ACE/examples/APG/Threads/Message_Receiver.h
@@ -10,7 +10,7 @@
 #include "ace/Message_Block.h"
 #include "ace/SOCK_Stream.h"
 #include "ace/Svc_Handler.h"
-#include "ace/Synch.h"
+#include "ace/Synch_Traits.h"
 #include "ace/Task.h"
 
 // Listing 1 code/ch12

--- a/ACE/examples/APG/Timers/CB.cpp
+++ b/ACE/examples/APG/Timers/CB.cpp
@@ -1,5 +1,8 @@
-#include "ace/Log_Msg.h"
 #include "CB.h"
+
+#include "ace/Log_Msg.h"
+#include "ace/Synch.h"
+
 #include "TimerDispatcher.h"
 
 CB::CB () : count_(0)

--- a/ACE/examples/APG/Timers/PTimerDispatcher.h
+++ b/ACE/examples/APG/Timers/PTimerDispatcher.h
@@ -2,8 +2,9 @@
 #if !defined(PTIMER_DISPATCHER_H)
 #define PTIMER_DISPATCHER_H
 
+#include "ace/Event.h"
 #include "ace/Singleton.h"
-#include "ace/Synch.h"  // needed for ACE_Event
+#include "ace/Synch_Traits.h"
 
 #include "Upcall.h"
 class PCB;
@@ -31,7 +32,7 @@ private:
   ACE_Event timer_;
 };
 
-typedef ACE_Singleton<PTimer_Dispatcher, ACE_Null_Mutex> PTimer;
+typedef ACE_Singleton<PTimer_Dispatcher, ACE_SYNCH_NULL_MUTEX> PTimer;
 
 #endif /*TIMER_DISPATCHER_H*/
 

--- a/ACE/examples/APG/Timers/TimerDispatcher.cpp
+++ b/ACE/examples/APG/Timers/TimerDispatcher.cpp
@@ -1,4 +1,7 @@
 #include "TimerDispatcher.h"
+
+#include "ace/Abstract_Timer_Queue.h"
+
 // Listing 1 code/ch20
 void Timer_Dispatcher::wait_for_event (void)
 {

--- a/ACE/examples/APG/Timers/TimerDispatcher.h
+++ b/ACE/examples/APG/Timers/TimerDispatcher.h
@@ -2,9 +2,10 @@
 #if !defined(TIMER_DISPATCHER_H)
 #define TIMER_DISPATCHER_H
 
+#include "ace/Event.h"
 #include "ace/Event_Handler.h"
 #include "ace/Singleton.h"
-#include "ace/Synch.h"  // needed for ACE_Event
+#include "ace/Synch_Traits.h"
 #include "ace/Timer_Queue.h"
 
 // Listing 1 code/ch20
@@ -31,7 +32,7 @@ private:
   ACE_Event timer_;
 };
 
-typedef ACE_Singleton<Timer_Dispatcher, ACE_Null_Mutex> Timer;
+typedef ACE_Singleton<Timer_Dispatcher, ACE_SYNCH_NULL_MUTEX> Timer;
 // Listing 1
 
 #endif /*TIMER_DISPATCHER_H*/

--- a/ACE/examples/APG/Timers/TimerDispatcher.h
+++ b/ACE/examples/APG/Timers/TimerDispatcher.h
@@ -6,7 +6,7 @@
 #include "ace/Event_Handler.h"
 #include "ace/Singleton.h"
 #include "ace/Synch_Traits.h"
-#include "ace/Timer_Queue.h"
+#include "ace/Timer_Queuefwd.h"
 
 // Listing 1 code/ch20
 class Timer_Dispatcher

--- a/ACE/examples/APG/Timers/Upcall.h
+++ b/ACE/examples/APG/Timers/Upcall.h
@@ -2,21 +2,21 @@
 #if !defined(UPCALL_H)
 #define UPCALL_H
 
+#include "ace/Synch_Traits.h"
 #include "ace/Timer_Queue_T.h"
 #include "ace/Timer_Heap_T.h"
-#include "ace/Synch.h"
 
 #include "PCB.h"
 
 // Listing 1 code/ch20
 class UpcallHandler;
 
-typedef ACE_Timer_Queue_T<PCB*, UpcallHandler, ACE_Null_Mutex>
+typedef ACE_Timer_Queue_T<PCB*, UpcallHandler, ACE_SYNCH_NULL_MUTEX>
   PTimerQueue;
 
 // Create a special heap-based timer queue that allows you to
 // control exactly how timer evetns are handled.
-typedef ACE_Timer_Heap_T<PCB*, UpcallHandler, ACE_Null_Mutex>
+typedef ACE_Timer_Heap_T<PCB*, UpcallHandler, ACE_SYNCH_NULL_MUTEX>
   PTimerHeap;
 // Listing 1
 

--- a/ACE/examples/APG/Timers/Upcall.h
+++ b/ACE/examples/APG/Timers/Upcall.h
@@ -11,12 +11,18 @@
 // Listing 1 code/ch20
 class UpcallHandler;
 
-typedef ACE_Timer_Queue_T<PCB*, UpcallHandler, ACE_SYNCH_NULL_MUTEX>
+typedef ACE_Timer_Queue_T<PCB,
+                          UpcallHandler,
+                          ACE_SYNCH_NULL_MUTEX,
+                          ACE_Default_Time_Policy>
   PTimerQueue;
 
 // Create a special heap-based timer queue that allows you to
 // control exactly how timer evetns are handled.
-typedef ACE_Timer_Heap_T<PCB*, UpcallHandler, ACE_SYNCH_NULL_MUTEX>
+typedef ACE_Timer_Heap_T<PCB,
+                         UpcallHandler,
+                         ACE_SYNCH_NULL_MUTEX,
+                         ACE_Default_Time_Policy>
   PTimerHeap;
 // Listing 1
 

--- a/ACE/examples/Bounded_Packet_Relay/Thread_Bounded_Packet_Relay.cpp
+++ b/ACE/examples/Bounded_Packet_Relay/Thread_Bounded_Packet_Relay.cpp
@@ -451,7 +451,7 @@ int
 User_Input_Task::clear_all_timers (void)
 {
   // loop through the timers in the queue, cancelling each one
-  for (ACE_Timer_Node_T <ACE_Event_Handler *> *node;
+  for (ACE_Timer_Node_T <ACE_Event_Handler> *node;
        (node = queue_->timer_queue ()->get_first ()) != 0;
        )
     queue_->timer_queue ()->cancel (node->get_timer_id (), 0, 0);
@@ -481,7 +481,7 @@ BPR_Handler_Base::clear_all_timers (void *)
 {
   // Loop through the timers in the queue, cancelling each one.
 
-  for (ACE_Timer_Node_T <ACE_Event_Handler *> *node;
+  for (ACE_Timer_Node_T <ACE_Event_Handler> *node;
        (node = queue_.timer_queue ()->get_first ()) != 0;
        )
     queue_.timer_queue ()->cancel (node->get_timer_id (), 0, 0);

--- a/ACE/examples/Bounded_Packet_Relay/Thread_Bounded_Packet_Relay.h
+++ b/ACE/examples/Bounded_Packet_Relay/Thread_Bounded_Packet_Relay.h
@@ -21,23 +21,27 @@
 # pragma once
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
+#include "ace/Event_Handler_Handle_Timeout_Upcall.h"
+#include "ace/Synch_Traits.h"
 #include "ace/Task.h"
 #include "ace/Timer_Heap_T.h"
 #include "ace/Timer_Queue_Adapters.h"
-#include "ace/Event_Handler_Handle_Timeout_Upcall.h"
+
 #include "BPR_Drivers.h"
 
 // These typedefs ensure that we use the minimal amount of locking
 // necessary.
 typedef ACE_Event_Handler_Handle_Timeout_Upcall
         Upcall;
-typedef ACE_Timer_Heap_T<ACE_Event_Handler *,
+typedef ACE_Timer_Heap_T<ACE_Event_Handler,
                          Upcall,
-                         ACE_Null_Mutex>
+                         ACE_SYNCH_NULL_MUTEX,
+                         ACE_Default_Time_Policy>
         Timer_Heap;
-typedef ACE_Timer_Heap_Iterator_T<ACE_Event_Handler *,
+typedef ACE_Timer_Heap_Iterator_T<ACE_Event_Handler,
                                   Upcall,
-                                  ACE_Null_Mutex>
+                                  ACE_SYNCH_NULL_MUTEX,
+                                  ACE_Default_Time_Policy>
         Timer_Heap_Iterator;
 typedef ACE_Thread_Timer_Queue_Adapter<Timer_Heap>
         Thread_Timer_Queue;

--- a/ACE/examples/C++NPv2/Logging_Event_Handler_Ex.cpp
+++ b/ACE/examples/C++NPv2/Logging_Event_Handler_Ex.cpp
@@ -3,7 +3,8 @@
 */
 
 #include "Logging_Event_Handler_Ex.h"
-#include "ace/Timer_Queue.h"
+
+#include "ace/Abstract_Timer_Queue.h"
 
 int Logging_Event_Handler_Ex::handle_input (ACE_HANDLE h) {
   time_of_last_log_record_ =

--- a/ACE/examples/C++NPv2/TP_Logging_Server.cpp
+++ b/ACE/examples/C++NPv2/TP_Logging_Server.cpp
@@ -5,6 +5,8 @@
 #include "ace/OS_Memory.h"
 #include "ace/Guard_T.h"
 #include "ace/Message_Block.h"
+#include "ace/Synch.h"
+
 #include "TP_Logging_Server.h"
 
 int TP_Logging_Handler::handle_input (ACE_HANDLE) {

--- a/ACE/examples/C++NPv2/TP_Logging_Server.h
+++ b/ACE/examples/C++NPv2/TP_Logging_Server.h
@@ -7,8 +7,9 @@
 
 #include "ace/Auto_Ptr.h"
 #include "ace/Singleton.h"
-#include "ace/Synch.h"
+#include "ace/Synch_Traits.h"
 #include "ace/Task.h"
+
 #include "Logging_Acceptor.h"
 #include "Logging_Event_Handler.h"
 #include "Reactor_Logging_Server_T.h"
@@ -29,7 +30,7 @@ public:
   virtual int svc (void);
 };
 
-typedef ACE_Unmanaged_Singleton<TP_Logging_Task, ACE_Null_Mutex>
+typedef ACE_Unmanaged_Singleton<TP_Logging_Task, ACE_SYNCH_NULL_MUTEX>
         TP_LOGGING_TASK;
 
 /*******************************************************/

--- a/ACE/examples/Reactor/Proactor/test_multiple_loops.cpp
+++ b/ACE/examples/Reactor/Proactor/test_multiple_loops.cpp
@@ -100,7 +100,7 @@ ACE_TMAIN (int, ACE_TCHAR *[])
 
   // Register a 2 second timer.
   ACE_Time_Value foo_tv (2);
-  if (proactor.schedule_timer (handler,
+  if (proactor.schedule_timer (&handler,
                                (void *) "Proactor",
                                ACE_Time_Value::zero,
                                foo_tv) == -1)

--- a/ACE/examples/Reactor/Proactor/test_timeout.cpp
+++ b/ACE/examples/Reactor/Proactor/test_timeout.cpp
@@ -84,7 +84,7 @@ ACE_TMAIN (int, ACE_TCHAR *[])
 
   // Register a 2 second timer.
   ACE_Time_Value foo_tv (2);
-  if (ACE_Proactor::instance ()->schedule_timer (handler,
+  if (ACE_Proactor::instance ()->schedule_timer (&handler,
                                                  (void *) "Foo",
                                                  ACE_Time_Value::zero,
                                                  foo_tv) == -1)
@@ -92,7 +92,7 @@ ACE_TMAIN (int, ACE_TCHAR *[])
 
   // Register a 3 second timer.
   ACE_Time_Value bar_tv (3);
-  if (ACE_Proactor::instance ()->schedule_timer (handler,
+  if (ACE_Proactor::instance ()->schedule_timer (&handler,
                                                  (void *) "Bar",
                                                  ACE_Time_Value::zero,
                                                  bar_tv) == -1)

--- a/ACE/examples/Timer_Queue/Custom_Handler.h
+++ b/ACE/examples/Timer_Queue/Custom_Handler.h
@@ -15,8 +15,10 @@
 #ifndef _CUSTOM_HANDLER_H_
 #define _CUSTOM_HANDLER_H_
 
-#include "ace/Timer_Queue.h"
 #include "ace/svc_export.h"
+#include "ace/Synch_Traits.h"
+#include "ace/Time_Value.h"
+#include "ace/Timer_Queue_T.h"
 
 /**
  * @class Custom_Handler
@@ -62,32 +64,33 @@ class ACE_Svc_Export Custom_Handler_Upcall
 {
     public:
 
-        typedef ACE_Timer_Queue_T<Custom_Handler*,
+        typedef ACE_Timer_Queue_T<Custom_Handler,
                                   Custom_Handler_Upcall,
-                                  ACE_Null_Mutex> TTimerQueue;
+                                  ACE_SYNCH_NULL_MUTEX,
+                                  ACE_Default_Time_Policy> TTimerQueue;
 
         // Default constructor
-        Custom_Handler_Upcall()
+        Custom_Handler_Upcall ()
         {
         }
 
         // Destructor.
-        ~Custom_Handler_Upcall()
+        ~Custom_Handler_Upcall ()
         {
         }
 
         // This method is called when a timer is registered.
-        int registration(TTimerQueue& timer_queue,
-                         Custom_Handler* handler,
-                         const void* arg);
+        int registration (TTimerQueue& timer_queue,
+                          Custom_Handler* handler,
+                          const void* arg);
 
         // This method is called before the timer expires.
-        int preinvoke(TTimerQueue& timer_queue,
-                      Custom_Handler* handler,
-                      const void* arg,
-                      int recurring_timer,
-                      const ACE_Time_Value& cur_time,
-                      const void*& upcall_act);
+        int preinvoke (TTimerQueue& timer_queue,
+                       Custom_Handler* handler,
+                       const void* arg,
+                       int recurring_timer,
+                       const ACE_Time_Value& cur_time,
+                       const void*& upcall_act);
 
         // This method is called when the timer expires.
         int timeout (TTimerQueue& timer_queue,
@@ -97,30 +100,30 @@ class ACE_Svc_Export Custom_Handler_Upcall
                      const ACE_Time_Value& cur_time);
 
         // This method is called after the timer expires.
-        int postinvoke(TTimerQueue& timer_queue,
-                       Custom_Handler* handler,
-                       const void* arg,
-                       int recurring_timer,
-                       const ACE_Time_Value& cur_time,
-                       const void* upcall_act);
+        int postinvoke (TTimerQueue& timer_queue,
+                        Custom_Handler* handler,
+                        const void* arg,
+                        int recurring_timer,
+                        const ACE_Time_Value& cur_time,
+                        const void* upcall_act);
 
         // This method is called when a handler is canceled
-        int cancel_type(TTimerQueue& timer_queue,
-                        Custom_Handler* handler,
-                        int dont_call,
-                        int& requires_reference_counting);
-
-        // This method is called when a timer is canceled
-        int cancel_timer(TTimerQueue& timer_queue,
+        int cancel_type (TTimerQueue& timer_queue,
                          Custom_Handler* handler,
                          int dont_call,
-                         int requires_reference_counting);
+                         int& requires_reference_counting);
+
+        // This method is called when a timer is canceled
+        int cancel_timer (TTimerQueue& timer_queue,
+                          Custom_Handler* handler,
+                          int dont_call,
+                          int requires_reference_counting);
 
         // This method is called when the timer queue is destroyed and
         // the timer is still contained in it
-        int deletion(TTimerQueue& timer_queue,
-                     Custom_Handler* handler,
-                     const void* arg);
+        int deletion (TTimerQueue& timer_queue,
+                      Custom_Handler* handler,
+                      const void* arg);
 };
 
 #endif

--- a/ACE/examples/Timer_Queue/Thread_Timer_Queue_Custom_Handler_Test.h
+++ b/ACE/examples/Timer_Queue/Thread_Timer_Queue_Custom_Handler_Test.h
@@ -26,7 +26,6 @@
 #include "ace/Timer_Heap_T.h"
 #include "ace/Timer_Queue_Adapters.h"
 #include "ace/svc_export.h"
-#include "ace/Condition_Recursive_Thread_Mutex.h"
 #include "Driver.h"
 #include "Custom_Handler.h"
 

--- a/ACE/examples/Timer_Queue/Thread_Timer_Queue_Custom_Handler_Test.h
+++ b/ACE/examples/Timer_Queue/Thread_Timer_Queue_Custom_Handler_Test.h
@@ -16,30 +16,32 @@
 #ifndef _THREAD_TIMER_QUEUE_TEST_H_
 #define _THREAD_TIMER_QUEUE_TEST_H_
 
-#include "ace/Task.h"
-
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 # pragma once
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
-#include "ace/Null_Mutex.h"
+#include "ace/svc_export.h"
+#include "ace/Synch_Traits.h"
+#include "ace/Task.h"
 #include "ace/Timer_Heap_T.h"
 #include "ace/Timer_Queue_Adapters.h"
-#include "ace/svc_export.h"
+
 #include "Driver.h"
 #include "Custom_Handler.h"
 
 // These typedefs ensure that we use the minimal amount of locking
 // necessary.
-typedef ACE_Timer_Heap_T<Custom_Handler*,
+typedef ACE_Timer_Heap_T<Custom_Handler,
                          Custom_Handler_Upcall,
-                         ACE_Null_Mutex>
+                         ACE_SYNCH_NULL_MUTEX,
+                         ACE_Default_Time_Policy>
         Timer_Heap;
-typedef ACE_Timer_Heap_Iterator_T<Custom_Handler*,
+typedef ACE_Timer_Heap_Iterator_T<Custom_Handler,
                                   Custom_Handler_Upcall,
-                                  ACE_Null_Mutex>
+                                  ACE_SYNCH_NULL_MUTEX,
+                                  ACE_Default_Time_Policy>
         Timer_Heap_Iterator;
-typedef ACE_Thread_Timer_Queue_Adapter<Timer_Heap, Custom_Handler*>
+typedef ACE_Thread_Timer_Queue_Adapter<Timer_Heap, Custom_Handler>
         Thread_Timer_Queue;
 
 // Forward declaration.

--- a/ACE/examples/Timer_Queue/Thread_Timer_Queue_Test.cpp
+++ b/ACE/examples/Timer_Queue/Thread_Timer_Queue_Test.cpp
@@ -22,7 +22,8 @@
 #include "ace/Condition_T.h"
 #include "ace/Thread_Mutex.h"
 
-
+// *NOTE*: explicit template instantiation required here...
+template class ACE_Condition<ACE_Recursive_Thread_Mutex>;
 
 // Administrivia methods...
 Handler::Handler(const ACE_Time_Value &expiration_time)

--- a/ACE/examples/Timer_Queue/Thread_Timer_Queue_Test.cpp
+++ b/ACE/examples/Timer_Queue/Thread_Timer_Queue_Test.cpp
@@ -22,9 +22,6 @@
 #include "ace/Condition_T.h"
 #include "ace/Thread_Mutex.h"
 
-// *NOTE*: explicit template instantiation required here...
-template class ACE_Condition<ACE_Recursive_Thread_Mutex>;
-
 // Administrivia methods...
 Handler::Handler(const ACE_Time_Value &expiration_time)
   :  expires_ (expiration_time),

--- a/ACE/examples/Timer_Queue/Thread_Timer_Queue_Test.h
+++ b/ACE/examples/Timer_Queue/Thread_Timer_Queue_Test.h
@@ -16,18 +16,18 @@
 #ifndef _THREAD_TIMER_QUEUE_TEST_H_
 #define _THREAD_TIMER_QUEUE_TEST_H_
 
-#include "ace/Task.h"
-
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 # pragma once
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
-#include "ace/Null_Mutex.h"
+#include "ace/Event_Handler_Handle_Timeout_Upcall.h"
+#include "ace/Synch_Traits.h"
+#include "ace/Task.h"
+#include "ace/Time_Value.h"
 #include "ace/Timer_Heap_T.h"
 #include "ace/Timer_Queue_Adapters.h"
 #include "ace/svc_export.h"
-#include "ace/Condition_Recursive_Thread_Mutex.h"
-#include "ace/Event_Handler_Handle_Timeout_Upcall.h"
+
 #include "Driver.h"
 
 // These typedefs ensure that we use the minimal amount of locking
@@ -36,11 +36,11 @@ typedef ACE_Event_Handler_Handle_Timeout_Upcall
         Upcall;
 typedef ACE_Timer_Heap_T<ACE_Event_Handler *,
                          Upcall,
-                         ACE_Null_Mutex>
+                         ACE_SYNCH_NULL_MUTEX>
         Timer_Heap;
 typedef ACE_Timer_Heap_Iterator_T<ACE_Event_Handler *,
                                   Upcall,
-                                  ACE_Null_Mutex>
+                                  ACE_SYNCH_NULL_MUTEX>
         Timer_Heap_Iterator;
 typedef ACE_Thread_Timer_Queue_Adapter<Timer_Heap>
         Thread_Timer_Queue;

--- a/ACE/examples/Timer_Queue/Thread_Timer_Queue_Test.h
+++ b/ACE/examples/Timer_Queue/Thread_Timer_Queue_Test.h
@@ -34,13 +34,15 @@
 // necessary.
 typedef ACE_Event_Handler_Handle_Timeout_Upcall
         Upcall;
-typedef ACE_Timer_Heap_T<ACE_Event_Handler *,
+typedef ACE_Timer_Heap_T<ACE_Event_Handler,
                          Upcall,
-                         ACE_SYNCH_NULL_MUTEX>
+                         ACE_SYNCH_NULL_MUTEX,
+                         ACE_Default_Time_Policy>
         Timer_Heap;
-typedef ACE_Timer_Heap_Iterator_T<ACE_Event_Handler *,
+typedef ACE_Timer_Heap_Iterator_T<ACE_Event_Handler,
                                   Upcall,
-                                  ACE_SYNCH_NULL_MUTEX>
+                                  ACE_SYNCH_NULL_MUTEX,
+                                  ACE_Default_Time_Policy>
         Timer_Heap_Iterator;
 typedef ACE_Thread_Timer_Queue_Adapter<Timer_Heap>
         Thread_Timer_Queue;

--- a/ACE/protocols/ace/HTBP/HTBP_Addr.h
+++ b/ACE/protocols/ace/HTBP/HTBP_Addr.h
@@ -19,7 +19,6 @@
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
 #include "ace/INET_Addr.h"
-#include "ace/Synch.h"
 #include "ace/SString.h"
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL

--- a/ACE/protocols/ace/HTBP/HTBP_Channel.cpp
+++ b/ACE/protocols/ace/HTBP/HTBP_Channel.cpp
@@ -13,13 +13,14 @@
 #include "HTBP_Channel.inl"
 #endif
 
-#include "HTBP_Session.h"
-#include "HTBP_Filter_Factory.h"
-
 #include "ace/Message_Block.h"
-#include "ace/Reactor.h"
 #include "ace/os_include/netinet/os_tcp.h"
 #include "ace/OS_NS_time.h"
+#include "ace/Reactor.h"
+#include "ace/Synch.h"
+
+#include "HTBP_Session.h"
+#include "HTBP_Filter_Factory.h"
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 

--- a/ACE/protocols/ace/HTBP/HTBP_Channel.h
+++ b/ACE/protocols/ace/HTBP/HTBP_Channel.h
@@ -12,6 +12,7 @@
 #define ACE_HTBP_CHANNEL_H
 #include /**/ "ace/pre.h"
 
+#include "ace/INET_Addr.h"
 #include "ace/SOCK_Stream.h"
 #include "ace/Message_Block.h"
 

--- a/ACE/protocols/ace/HTBP/HTBP_Filter.cpp
+++ b/ACE/protocols/ace/HTBP/HTBP_Filter.cpp
@@ -1,13 +1,13 @@
-#include "ace/Log_Msg.h"
-
-#include "HTBP_Session.h"
 #include "HTBP_Filter.h"
 
 #if !defined (__ACE_INLINE__)
 #include "HTBP_Filter.inl"
 #endif
 
+#include "ace/Log_Msg.h"
+#include "ace/Synch.h"
 
+#include "HTBP_Session.h"
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 

--- a/ACE/protocols/ace/HTBP/HTBP_Inside_Squid_Filter.cpp
+++ b/ACE/protocols/ace/HTBP/HTBP_Inside_Squid_Filter.cpp
@@ -1,12 +1,14 @@
-// ACE_HTBP_Filter.cpp
-#include "ace/Log_Msg.h"
-#include "ace/OS_NS_stdio.h"
-#include "HTBP_Session.h"
 #include "HTBP_Inside_Squid_Filter.h"
 
 #if !defined (__ACE_INLINE__)
 #include "HTBP_Inside_Squid_Filter.inl"
 #endif
+
+#include "ace/Log_Msg.h"
+#include "ace/OS_NS_stdio.h"
+#include "ace/Synch.h"
+
+#include "HTBP_Session.h"
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 

--- a/ACE/protocols/ace/HTBP/HTBP_Notifier.cpp
+++ b/ACE/protocols/ace/HTBP/HTBP_Notifier.cpp
@@ -8,9 +8,12 @@
  */
 //=============================================================================
 #include "HTBP_Notifier.h"
+
+#include "ace/Reactor.h"
+#include "ace/Synch.h"
+
 #include "HTBP_Channel.h"
 #include "HTBP_Session.h"
-#include "ace/Reactor.h"
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 

--- a/ACE/protocols/ace/HTBP/HTBP_Outside_Squid_Filter.cpp
+++ b/ACE/protocols/ace/HTBP/HTBP_Outside_Squid_Filter.cpp
@@ -1,11 +1,13 @@
-#include "ace/Log_Msg.h"
-
-#include "HTBP_Session.h"
 #include "HTBP_Outside_Squid_Filter.h"
 
 #if !defined (__ACE_INLINE__)
 #include "HTBP_Outside_Squid_Filter.inl"
 #endif
+
+#include "ace/Log_Msg.h"
+#include "ace/Synch.h"
+
+#include "HTBP_Session.h"
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 

--- a/ACE/protocols/ace/HTBP/HTBP_Session.cpp
+++ b/ACE/protocols/ace/HTBP/HTBP_Session.cpp
@@ -1,16 +1,17 @@
-// SOCK_Stream.cpp
-#include "ace/Log_Msg.h"
-
+#include "ace/Synch.h"
 #include "HTBP_Session.h"
-#include "ace/SOCK_Connector.h"
-#include "ace/Event_Handler.h"
-#include "ace/os_include/netinet/os_tcp.h"
-#include "HTBP_Filter.h"
-#include "HTBP_ID_Requestor.h"
 
 #if !defined (__ACE_INLINE__)
 #include "HTBP_Session.inl"
 #endif
+
+#include "ace/Event_Handler.h"
+#include "ace/Log_Msg.h"
+#include "ace/os_include/netinet/os_tcp.h"
+#include "ace/SOCK_Connector.h"
+
+#include "HTBP_Filter.h"
+#include "HTBP_ID_Requestor.h"
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 

--- a/ACE/protocols/ace/HTBP/HTBP_Session.h
+++ b/ACE/protocols/ace/HTBP/HTBP_Session.h
@@ -12,10 +12,10 @@
 #define ACE_HTBP_SESSION_H
 #include /**/ "ace/pre.h"
 
-#include "ace/SOCK_IO.h"
 #include "ace/Hash_Map_Manager.h"
-#include "ace/Synch.h"
+#include "ace/Synch_Traits.h"
 #include "ace/Message_Queue.h"
+#include "ace/SOCK_IO.h"
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 # pragma once

--- a/ACE/protocols/ace/HTBP/HTBP_Stream.cpp
+++ b/ACE/protocols/ace/HTBP/HTBP_Stream.cpp
@@ -9,10 +9,11 @@
 //=============================================================================
 #include "HTBP_Stream.h"
 
-#include "HTBP_Session.h"
-#include "HTBP_Filter_Factory.h"
-
 #include "ace/Message_Block.h"
+#include "ace/Synch.h"
+
+#include "HTBP_Filter_Factory.h"
+#include "HTBP_Session.h"
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 

--- a/ACE/protocols/ace/TMCast/LinkListener.hpp
+++ b/ACE/protocols/ace/TMCast/LinkListener.hpp
@@ -1,12 +1,11 @@
 // author    : Boris Kolpackov <boris@dre.vanderbilt.edu>
 
 // OS primitives
-#include <ace/OS_NS_string.h>
-#include <ace/OS_NS_stdlib.h>
-#include <ace/Synch.h>
-#include <ace/SOCK_Dgram_Mcast.h>
-#include <ace/Refcounted_Auto_Ptr.h>
-
+#include "ace/OS_NS_string.h"
+#include "ace/OS_NS_stdlib.h"
+#include "ace/Refcounted_Auto_Ptr.h"
+#include "ace/SOCK_Dgram_Mcast.h"
+#include "ace/Synch_Traits.h"
 
 #include "Messaging.hpp"
 #include "Protocol.hpp"
@@ -150,7 +149,7 @@ namespace ACE_TMCast
 
   private:
     // FUZZ: disable check_for_ACE_Guard
-    typedef ACE_Guard<ACE_Thread_Mutex> AutoLock;
+    typedef ACE_Guard<ACE_SYNCH_MUTEX> AutoLock;
     // FUZZ: enable check_for_ACE_Guard
 
     ACE_hthread_t thread_;

--- a/ACE/protocols/ace/TMCast/Messaging.hpp
+++ b/ACE/protocols/ace/TMCast/Messaging.hpp
@@ -3,8 +3,8 @@
 #ifndef TMCAST_MESSAGING_HPP
 #define TMCAST_MESSAGING_HPP
 
-#include <ace/Synch.h>
-#include <ace/Bound_Ptr.h>
+#include "ace/Bound_Ptr.h"
+#include "ace/Synch_Traits.h"
 
 #include "MTQueue.hpp"
 
@@ -22,7 +22,7 @@ namespace ACE_TMCast
   MessagePtr;
 
   typedef
-  MTQueue<MessagePtr, ACE_Thread_Mutex, ACE_Condition<ACE_Thread_Mutex> >
+  MTQueue<MessagePtr, ACE_SYNCH_MUTEX, ACE_SYNCH_CONDITION >
   MessageQueue;
 
   struct MessageQueueAutoLock

--- a/ACE/protocols/ace/TMCast/TransactionController.hpp
+++ b/ACE/protocols/ace/TMCast/TransactionController.hpp
@@ -1,9 +1,9 @@
 // author    : Boris Kolpackov <boris@dre.vanderbilt.edu>
 
+#include "ace/Bound_Ptr.h"
 #include "ace/OS_NS_string.h"
 #include "ace/OS_NS_stdlib.h"
-#include "ace/Synch.h"
-#include "ace/Bound_Ptr.h"
+#include "ace/Synch_Traits.h"
 
 #include "Protocol.hpp"
 #include "Messaging.hpp"
@@ -366,7 +366,7 @@ namespace ACE_TMCast
 
   private:
     // FUZZ: disable check_for_ACE_Guard
-    typedef ACE_Guard<ACE_Thread_Mutex> AutoLock;
+    typedef ACE_Guard<ACE_SYNCH_MUTEX> AutoLock;
     // FUZZ: enable check_for_ACE_Guard
 
     // bool trace_;

--- a/ACE/protocols/tests/HTBP/Reactor_Tests/client.cpp
+++ b/ACE/protocols/tests/HTBP/Reactor_Tests/client.cpp
@@ -4,7 +4,6 @@
 
 #include "ace/Get_Opt.h"
 #include "ace/Log_Msg.h"
-#include "ace/OS.h"
 #include "ace/OS_NS_sys_socket.h"
 #include "ace/Synch.h"
 

--- a/ACE/protocols/tests/HTBP/Reactor_Tests/client.cpp
+++ b/ACE/protocols/tests/HTBP/Reactor_Tests/client.cpp
@@ -2,9 +2,11 @@
  * client for a reactor based connection establishment test using HTBP
  */
 
-#include "ace/Log_Msg.h"
 #include "ace/Get_Opt.h"
+#include "ace/Log_Msg.h"
+#include "ace/OS.h"
 #include "ace/OS_NS_sys_socket.h"
+#include "ace/Synch.h"
 
 #include "ace/HTBP/HTBP_Session.h"
 #include "ace/HTBP/HTBP_Stream.h"

--- a/ACE/protocols/tests/HTBP/Reactor_Tests/server.cpp
+++ b/ACE/protocols/tests/HTBP/Reactor_Tests/server.cpp
@@ -2,21 +2,21 @@
  * server for a reactor based connection establishment test using HTBP
  */
 
-#include "ace/Log_Msg.h"
-
-#include "ace/HTBP/HTBP_Session.h"
-#include "ace/HTBP/HTBP_Stream.h"
-#include "ace/HTBP/HTBP_Addr.h"
-
-#include "ace/SOCK_Acceptor.h"
-#include "ace/SOCK_Stream.h"
-#include "ace/Event_Handler.h"
-#include "ace/Reactor.h"
 #include "ace/Get_Opt.h"
+#include "ace/Event_Handler.h"
+#include "ace/Log_Msg.h"
 #include "ace/OS_NS_stdio.h"
 #include "ace/OS_NS_unistd.h"
 #include "ace/OS_NS_sys_socket.h"
 #include "ace/os_include/os_netdb.h"
+#include "ace/Reactor.h"
+#include "ace/SOCK_Acceptor.h"
+#include "ace/SOCK_Stream.h"
+#include "ace/Synch.h"
+
+#include "ace/HTBP/HTBP_Session.h"
+#include "ace/HTBP/HTBP_Stream.h"
+#include "ace/HTBP/HTBP_Addr.h"
 
 unsigned port = 8088;
 const ACE_TCHAR *notifier_file = 0;

--- a/ACE/protocols/tests/HTBP/Reactor_Tests/test_config.h
+++ b/ACE/protocols/tests/HTBP/Reactor_Tests/test_config.h
@@ -31,10 +31,11 @@
 // This first #undef protects against command-line definitions.
 #undef ACE_NDEBUG
 #include "ace/streams.h"
-#include "ace/Singleton.h"
-#include "ace/Synch.h"
-#include "ace/Log_Msg.h"
+
 #include "ace/ACE.h"
+#include "ace/Log_Msg.h"
+#include "ace/Singleton.h"
+#include "ace/Synch_Traits.h"
 
 // The second #undef protects against being reset in a config.h file.
 #undef ACE_NDEBUG
@@ -303,7 +304,7 @@ randomize (int array[], size_t size)
     }
 }
 
-typedef ACE_Singleton<ACE_Test_Output, ACE_Null_Mutex> ace_file_stream;
+typedef ACE_Singleton<ACE_Test_Output, ACE_NULL_MUTEX> ace_file_stream;
 
 #if defined (ACE_HAS_EXPLICIT_STATIC_TEMPLATE_MEMBER_INSTANTIATION)
 template ACE_Singleton<ACE_Test_Output, ACE_Null_Mutex> *

--- a/ACE/protocols/tests/HTBP/Send_Large_Msg/client.cpp
+++ b/ACE/protocols/tests/HTBP/Send_Large_Msg/client.cpp
@@ -1,12 +1,13 @@
+#include "ace/Get_Opt.h"
+#include "ace/Log_Msg.h"
+#include "ace/OS_NS_sys_socket.h"
+#include "ace/Synch.h"
+
 #include "ace/HTBP/HTBP_Session.h"
 #include "ace/HTBP/HTBP_Stream.h"
 #include "ace/HTBP/HTBP_Addr.h"
 #include "ace/HTBP/HTBP_ID_Requestor.h"
 #include "ace/HTBP/HTBP_Environment.h"
-
-#include "ace/Log_Msg.h"
-#include "ace/Get_Opt.h"
-#include "ace/OS_NS_sys_socket.h"
 
 const ssize_t Send_Size = 4*1024;
 const size_t Loops = 10;

--- a/ACE/protocols/tests/HTBP/Send_Large_Msg/server.cpp
+++ b/ACE/protocols/tests/HTBP/Send_Large_Msg/server.cpp
@@ -1,6 +1,5 @@
 #include "ace/Get_Opt.h"
 #include "ace/Log_Msg.h"
-#include "ace/OS.h"
 #include "ace/OS_NS_stdio.h"
 #include "ace/OS_NS_sys_socket.h"
 #include "ace/os_include/os_netdb.h"

--- a/ACE/protocols/tests/HTBP/Send_Large_Msg/server.cpp
+++ b/ACE/protocols/tests/HTBP/Send_Large_Msg/server.cpp
@@ -1,15 +1,16 @@
-#include "ace/Log_Msg.h"
 #include "ace/Get_Opt.h"
+#include "ace/Log_Msg.h"
+#include "ace/OS.h"
+#include "ace/OS_NS_stdio.h"
+#include "ace/OS_NS_sys_socket.h"
+#include "ace/os_include/os_netdb.h"
+#include "ace/SOCK_Acceptor.h"
+#include "ace/SOCK_Stream.h"
+#include "ace/Synch.h"
 
 #include "ace/HTBP/HTBP_Session.h"
 #include "ace/HTBP/HTBP_Stream.h"
 #include "ace/HTBP/HTBP_Addr.h"
-
-#include "ace/SOCK_Acceptor.h"
-#include "ace/SOCK_Stream.h"
-#include "ace/OS_NS_stdio.h"
-#include "ace/OS_NS_sys_socket.h"
-#include "ace/os_include/os_netdb.h"
 
 const size_t Send_Size = 4*1024;
 const size_t Loops = 10;

--- a/ACE/protocols/tests/HTBP/Send_Recv_Tests/client.cpp
+++ b/ACE/protocols/tests/HTBP/Send_Recv_Tests/client.cpp
@@ -17,7 +17,6 @@
 //=============================================================================
 
 #include "ace/Get_Opt.h"
-#include "ace/OS.h"
 #include "ace/OS_NS_sys_socket.h"
 #include "ace/Synch.h"
 #include "ace/Thread.h"

--- a/ACE/protocols/tests/HTBP/Send_Recv_Tests/client.cpp
+++ b/ACE/protocols/tests/HTBP/Send_Recv_Tests/client.cpp
@@ -16,19 +16,20 @@
  */
 //=============================================================================
 
-
-#include "ace/HTBP/HTBP_Stream.h"
-#include "ace/HTBP/HTBP_Session.h"
-#include "ace/HTBP/HTBP_ID_Requestor.h"
-#include "ace/HTBP/HTBP_Environment.h"
-
+#include "ace/Get_Opt.h"
+#include "ace/OS.h"
+#include "ace/OS_NS_sys_socket.h"
+#include "ace/Synch.h"
 #include "ace/Thread.h"
 #include "ace/Thread_Manager.h"
 #include "ace/SOCK_Connector.h"
 #include "ace/SOCK_Acceptor.h"
 #include "ace/SOCK_Stream.h"
-#include "ace/Get_Opt.h"
-#include "ace/OS_NS_sys_socket.h"
+
+#include "ace/HTBP/HTBP_Stream.h"
+#include "ace/HTBP/HTBP_Session.h"
+#include "ace/HTBP/HTBP_ID_Requestor.h"
+#include "ace/HTBP/HTBP_Environment.h"
 
 // Change to non-zero if test fails
 static int Test_Result = 0;

--- a/ACE/protocols/tests/HTBP/Send_Recv_Tests/server.cpp
+++ b/ACE/protocols/tests/HTBP/Send_Recv_Tests/server.cpp
@@ -17,7 +17,6 @@
 //=============================================================================
 
 #include "ace/Get_Opt.h"
-#include "ace/OS.h"
 #include "ace/OS_NS_stdio.h"
 #include "ace/OS_NS_sys_socket.h"
 #include "ace/os_include/os_netdb.h"

--- a/ACE/protocols/tests/HTBP/Send_Recv_Tests/server.cpp
+++ b/ACE/protocols/tests/HTBP/Send_Recv_Tests/server.cpp
@@ -16,21 +16,22 @@
  */
 //=============================================================================
 
+#include "ace/Get_Opt.h"
+#include "ace/OS.h"
+#include "ace/OS_NS_stdio.h"
+#include "ace/OS_NS_sys_socket.h"
+#include "ace/os_include/os_netdb.h"
+#include "ace/SOCK_Connector.h"
+#include "ace/SOCK_Acceptor.h"
+#include "ace/SOCK_Stream.h"
+#include "ace/Synch.h"
+#include "ace/Thread.h"
+#include "ace/Thread_Manager.h"
 
 #include "ace/HTBP/HTBP_Stream.h"
 #include "ace/HTBP/HTBP_Session.h"
 #include "ace/HTBP/HTBP_ID_Requestor.h"
 #include "ace/HTBP/HTBP_Environment.h"
-
-#include "ace/Thread.h"
-#include "ace/Thread_Manager.h"
-#include "ace/SOCK_Connector.h"
-#include "ace/SOCK_Acceptor.h"
-#include "ace/SOCK_Stream.h"
-#include "ace/Get_Opt.h"
-#include "ace/OS_NS_stdio.h"
-#include "ace/OS_NS_sys_socket.h"
-#include "ace/os_include/os_netdb.h"
 
 // Change to non-zero if test fails
 static int Test_Result = 0;

--- a/ACE/protocols/tests/HTBP/ping/client.cpp
+++ b/ACE/protocols/tests/HTBP/ping/client.cpp
@@ -5,7 +5,6 @@
 #include "ace/ACE.h"
 #include "ace/Log_Msg.h"
 #include "ace/Get_Opt.h"
-#include "ace/OS.h"
 #include "ace/OS_NS_sys_socket.h"
 #include "ace/os_include/os_netdb.h"
 #include "ace/Synch.h"

--- a/ACE/protocols/tests/HTBP/ping/client.cpp
+++ b/ACE/protocols/tests/HTBP/ping/client.cpp
@@ -5,8 +5,10 @@
 #include "ace/ACE.h"
 #include "ace/Log_Msg.h"
 #include "ace/Get_Opt.h"
+#include "ace/OS.h"
 #include "ace/OS_NS_sys_socket.h"
 #include "ace/os_include/os_netdb.h"
+#include "ace/Synch.h"
 
 #include "ace/HTBP/HTBP_Session.h"
 #include "ace/HTBP/HTBP_Stream.h"

--- a/ACE/protocols/tests/HTBP/ping/server.cpp
+++ b/ACE/protocols/tests/HTBP/ping/server.cpp
@@ -2,18 +2,19 @@
  * server for a basic connection establishment test using HTBP
  */
 
+#include "ace/Get_Opt.h"
 #include "ace/Log_Msg.h"
+#include "ace/OS.h"
+#include "ace/OS_NS_stdio.h"
+#include "ace/OS_NS_sys_socket.h"
+#include "ace/os_include/os_netdb.h"
+#include "ace/SOCK_Acceptor.h"
+#include "ace/SOCK_Stream.h"
+#include "ace/Synch.h"
 
 #include "ace/HTBP/HTBP_Session.h"
 #include "ace/HTBP/HTBP_Stream.h"
 #include "ace/HTBP/HTBP_Addr.h"
-
-#include "ace/SOCK_Acceptor.h"
-#include "ace/SOCK_Stream.h"
-#include "ace/Get_Opt.h"
-#include "ace/OS_NS_stdio.h"
-#include "ace/OS_NS_sys_socket.h"
-#include "ace/os_include/os_netdb.h"
 
 unsigned port = 8088;
 const ACE_TCHAR *notifier_file = 0;

--- a/ACE/protocols/tests/HTBP/ping/server.cpp
+++ b/ACE/protocols/tests/HTBP/ping/server.cpp
@@ -4,7 +4,6 @@
 
 #include "ace/Get_Opt.h"
 #include "ace/Log_Msg.h"
-#include "ace/OS.h"
 #include "ace/OS_NS_stdio.h"
 #include "ace/OS_NS_sys_socket.h"
 #include "ace/os_include/os_netdb.h"

--- a/ACE/tests/Bug_2772_Regression_Test.cpp
+++ b/ACE/tests/Bug_2772_Regression_Test.cpp
@@ -16,6 +16,9 @@
 #include "ace/Condition_Recursive_Thread_Mutex.h"
 #include "ace/Thread.h"
 
+// *NOTE*: explicit template instantiation required here...
+template class ACE_Condition<ACE_Recursive_Thread_Mutex>;
+
 class ThreadTest
 {
  public:

--- a/ACE/tests/Bug_2772_Regression_Test.cpp
+++ b/ACE/tests/Bug_2772_Regression_Test.cpp
@@ -16,9 +16,6 @@
 #include "ace/Condition_Recursive_Thread_Mutex.h"
 #include "ace/Thread.h"
 
-// *NOTE*: explicit template instantiation required here...
-template class ACE_Condition<ACE_Recursive_Thread_Mutex>;
-
 class ThreadTest
 {
  public:

--- a/ACE/tests/Bug_4055_Regression_Test.cpp
+++ b/ACE/tests/Bug_4055_Regression_Test.cpp
@@ -38,7 +38,7 @@ create_timer_queue (void)
 {
   ACE_Timer_Queue * tmq = 0;
 
-  typedef ACE_Timer_Heap_T<ACE_Event_Handler *,
+  typedef ACE_Timer_Heap_T<ACE_Event_Handler,
                            ACE_Event_Handler_Handle_Timeout_Upcall,
                            ACE_SYNCH_RECURSIVE_MUTEX,
                            ACE_HR_Time_Policy> timer_queue_type;

--- a/ACE/tests/Monotonic_Message_Queue_Test.cpp
+++ b/ACE/tests/Monotonic_Message_Queue_Test.cpp
@@ -52,7 +52,7 @@ create_timer_queue (void)
 {
   ACE_Timer_Queue * tmq = 0;
 
-  typedef ACE_Timer_Heap_T<ACE_Event_Handler *,
+  typedef ACE_Timer_Heap_T<ACE_Event_Handler,
                            ACE_Event_Handler_Handle_Timeout_Upcall,
                            ACE_SYNCH_RECURSIVE_MUTEX,
                            ACE_HR_Time_Policy> timer_queue_type;

--- a/ACE/tests/Proactor_File_Test.cpp
+++ b/ACE/tests/Proactor_File_Test.cpp
@@ -372,7 +372,7 @@ run_main(int /*argc*/, ACE_TCHAR * /*argv*/[])
     // start the repeating timer for data transmission
 
     ACE_Time_Value repeatTime(0, 50000); // 0.05 second time interval
-    ACE_Proactor::instance()->schedule_repeating_timer(fileIOHandler,
+    ACE_Proactor::instance()->schedule_repeating_timer(&fileIOHandler,
                                                        (void *) (100),
                                                        repeatTime);
 

--- a/ACE/tests/Recursive_Condition_Bug_Test.cpp
+++ b/ACE/tests/Recursive_Condition_Bug_Test.cpp
@@ -23,6 +23,9 @@
 #include "ace/Timer_Queue_Adapters.h"
 #include "ace/Condition_Recursive_Thread_Mutex.h"
 
+// *NOTE*: explicit template instantiation required here...
+template class ACE_Condition<ACE_Recursive_Thread_Mutex>;
+
 #if defined (ACE_HAS_THREADS)
 
 // Number of iterations for the performance tests.

--- a/ACE/tests/Recursive_Condition_Bug_Test.cpp
+++ b/ACE/tests/Recursive_Condition_Bug_Test.cpp
@@ -14,14 +14,14 @@
  */
 //=============================================================================
 
-
-#include "test_config.h"
-#include "ace/OS_NS_sys_time.h"
-#include "ace/Task_T.h"
 #include "ace/Activation_Queue.h"
+#include "ace/OS_NS_sys_time.h"
+#include "ace/Synch.h"
+#include "ace/Task_T.h"
 #include "ace/Timer_Heap.h"
 #include "ace/Timer_Queue_Adapters.h"
-#include "ace/Condition_Recursive_Thread_Mutex.h"
+
+#include "test_config.h"
 
 // *NOTE*: explicit template instantiation required here...
 template class ACE_Condition<ACE_Recursive_Thread_Mutex>;

--- a/ACE/tests/Recursive_Condition_Test.cpp
+++ b/ACE/tests/Recursive_Condition_Test.cpp
@@ -25,9 +25,6 @@
 #if defined (ACE_HAS_THREADS)
 
 typedef ACE_Thread_Timer_Queue_Adapter<ACE_Timer_Heap> Thread_Timer_Queue;
-//
-//// *NOTE*: explicit template instantiation required here...  
-//template class ACE_Condition<ACE_Recursive_Thread_Mutex>;
 
 class Test_Handler : public ACE_Event_Handler
 {

--- a/ACE/tests/Recursive_Condition_Test.cpp
+++ b/ACE/tests/Recursive_Condition_Test.cpp
@@ -59,7 +59,6 @@ private:
 
 // These are for the basic functionality tests.
 ACE_SYNCH_RECURSIVE_MUTEX mutex_;
-//ACE_Condition<ACE_SYNCH_RECURSIVE_MUTEX> condition_ (mutex_);
 ACE_SYNCH_RECURSIVE_CONDITION condition_ (mutex_);
 // Test driver sets this to non-zero before spawning and to zero for
 // waiter.

--- a/ACE/tests/Recursive_Condition_Test.cpp
+++ b/ACE/tests/Recursive_Condition_Test.cpp
@@ -11,21 +11,23 @@
  */
 //=============================================================================
 
-
-#include "test_config.h"
-#include "ace/OS_NS_unistd.h"
-#include "ace/OS_NS_sys_time.h"
 #include "ace/Event_Handler.h"
 #include "ace/Log_Msg.h"
+#include "ace/OS_NS_sys_time.h"
+#include "ace/OS_NS_unistd.h"
+#include "ace/Synch.h"
 #include "ace/Thread_Manager.h"
 #include "ace/Timer_Heap.h"
 #include "ace/Timer_Queue_Adapters.h"
 
-
+#include "test_config.h"
 
 #if defined (ACE_HAS_THREADS)
 
 typedef ACE_Thread_Timer_Queue_Adapter<ACE_Timer_Heap> Thread_Timer_Queue;
+//
+//// *NOTE*: explicit template instantiation required here...  
+//template class ACE_Condition<ACE_Recursive_Thread_Mutex>;
 
 class Test_Handler : public ACE_Event_Handler
 {
@@ -60,7 +62,8 @@ private:
 
 // These are for the basic functionality tests.
 ACE_SYNCH_RECURSIVE_MUTEX mutex_;
-ACE_Condition<ACE_SYNCH_RECURSIVE_MUTEX> condition_ (mutex_);
+//ACE_Condition<ACE_SYNCH_RECURSIVE_MUTEX> condition_ (mutex_);
+ACE_SYNCH_RECURSIVE_CONDITION condition_ (mutex_);
 // Test driver sets this to non-zero before spawning and to zero for
 // waiter.
 int protected_int = 0;

--- a/ACE/tests/Refcounted_Auto_Ptr_Test.h
+++ b/ACE/tests/Refcounted_Auto_Ptr_Test.h
@@ -15,7 +15,7 @@
 #define ACE_TESTS_REFCOUNTED_AUTO_PTR_TEST_H
 
 #include "ace/Atomic_Op.h"
-#include "ace/Synch.h"
+#include "ace/Synch_Traits.h"
 
 struct Printer
 {

--- a/ACE/tests/Timer_Queue_Test.cpp
+++ b/ACE/tests/Timer_Queue_Test.cpp
@@ -685,7 +685,7 @@ run_main (int argc, ACE_TCHAR *argv[])
                   -1);
 
   // new (optimized) version
-  typedef ACE_Timer_Heap_T<ACE_Event_Handler *,
+  typedef ACE_Timer_Heap_T<ACE_Event_Handler,
                            ACE_Event_Handler_Handle_Timeout_Upcall,
                            ACE_SYNCH_RECURSIVE_MUTEX,
                            ACE_HR_Time_Policy>


### PR DESCRIPTION
this change request addresses two issues:

- a race condition in ACE_Thread_Manager in conjunction with ACE_Task::wait()
- a (major) cleanup of timer queue code. This includes:
   header sanitizations
   style guide compliant repairs
   fixes to the ACE_Timer_Hash class. This class code was unused, essentially broken and is now another (meta-)implementation that can be used standalone or with the other timer queue implementations. A future update of the timer queue test cases will involve this feature
   minor API changes that make the timer queue code more versatile