### PR TITLE
Updated mpc/mpb files to accurately reflect library dependencies.

### DIFF
--- a/TAO/MPC/config/ft_naming_serv.mpb
+++ b/TAO/MPC/config/ft_naming_serv.mpb
@@ -1,5 +1,5 @@
 // -*- MPC -*-
-project : orbsvcslib, naming_skel, portablegroup, ftnaming, ftnaming_replication, naming_serv, iortable, messaging_optional, svc_utils {
+project: orbsvcslib, naming_skel, portablegroup, ftnaming, ftnaming_replication, naming_serv, loadbalancing, iortable, messaging_optional, svc_utils {
   after     += FT_Naming_Serv
   libs      += TAO_FT_Naming_Serv
 }

--- a/TAO/MPC/config/ftnaming.mpb
+++ b/TAO/MPC/config/ftnaming.mpb
@@ -1,5 +1,5 @@
 // -*- MPC -*-
-project : naming, portablegroup, orbsvcslib, avoids_minimum_corba, avoids_corba_e_compact, avoids_corba_e_micro {
+project: naming_serv, portablegroup, orbsvcslib, avoids_minimum_corba, avoids_corba_e_compact, avoids_corba_e_micro {
   after     += FtNaming
   libs      += TAO_FtNaming
   tagchecks += FtNaming

--- a/TAO/MPC/config/ftnaming_replication.mpb
+++ b/TAO/MPC/config/ftnaming_replication.mpb
@@ -1,5 +1,5 @@
 // -*- MPC -*-
-project : avoids_minimum_corba, avoids_corba_e_compact, avoids_corba_e_micro {
+project: ftorbutils, avoids_minimum_corba, avoids_corba_e_compact, avoids_corba_e_micro {
   after     += FtNamingReplication
   libs      += TAO_FtNamingReplication
 }

--- a/TAO/orbsvcs/ImplRepo_Service/ImplRepo_Service.mpc
+++ b/TAO/orbsvcs/ImplRepo_Service/ImplRepo_Service.mpc
@@ -159,7 +159,7 @@ project(ImR_Locator_Service) : orbsvcsexe, install_bin, avoids_minimum_corba, av
 }
 
 
-project(ImR_Activator_Service) : orbsvcsexe, install, acexml, avoids_minimum_corba, avoids_corba_e_compact, avoids_corba_e_micro, messaging, svc_utils {
+project(ImR_Activator_Service) : orbsvcsexe, install, acexml, avoids_minimum_corba, avoids_corba_e_compact, avoids_corba_e_micro, messaging, dynamicinterface, svc_utils {
   exename  = tao_imr_activator
   after   += ImR_Activator
   libs    += TAO_ImR_Activator TAO_ImR_Activator_IDL TAO_ImR_Locator_IDL TAO_Async_ImR_Client_IDL


### PR DESCRIPTION
By listing all required libraries in mpb files, when executables are built all
used libraries (even indirectly used) will appear on the linker command line.
This is required for static libs and probably a good idea for shared libs.