### PR TITLE
Make the lock accessor const to prevent a const cast in user code

### DIFF
--- a/ACE/ace/Service_Repository.h
+++ b/ACE/ace/Service_Repository.h
@@ -133,7 +133,7 @@ public:
   void dump (void) const;
 
   /// Returns a reference to the lock used by the ACE_Service_Repository
-  ACE_SYNCH_RECURSIVE_MUTEX &lock (void);
+  ACE_SYNCH_RECURSIVE_MUTEX &lock (void) const;
 
   /// Declare the dynamic allocation hooks.
   ACE_ALLOC_HOOK_DECLARE;

--- a/ACE/ace/Service_Repository.inl
+++ b/ACE/ace/Service_Repository.inl
@@ -20,7 +20,7 @@ ACE_Service_Repository::current_size (void) const
 }
 
 ACE_INLINE ACE_SYNCH_RECURSIVE_MUTEX&
-ACE_Service_Repository::lock (void)
+ACE_Service_Repository::lock (void) const
 {
   return this->lock_;
 }


### PR DESCRIPTION
    * ACE/ace/Service_Repository.h:
    * ACE/ace/Service_Repository.inl: