### PR TITLE
Fix for new persistence failures that appeared after earlier commits.

### DIFF
--- a/TAO/orbsvcs/orbsvcs/Naming/Storable_Naming_Context.cpp
+++ b/TAO/orbsvcs/orbsvcs/Naming/Storable_Naming_Context.cpp
@@ -247,6 +247,7 @@ void TAO_Storable_Naming_Context::Write (TAO::Storable_Base& wrtr)
   ACE_TRACE("Write");
   TAO_Storable_Naming_Context_ReaderWriter rw(wrtr);
   rw.write(*this);
+
 }
 
 // Helpers function to load a new context into the binding_map
@@ -269,7 +270,7 @@ File_Open_Lock_and_Check::File_Open_Lock_and_Check
   try
     {
       this->init_no_load (method_type);
-      if (force_load)
+      if (force_load || method_type == CREATE_WITHOUT_FILE)
         this->reload ();
       else
         {
@@ -401,6 +402,16 @@ TAO_Storable_Naming_Context::TAO_Storable_Naming_Context (
     write_occurred_ (0)
 {
   ACE_TRACE("TAO_Storable_Naming_Context");
+  // Create a temporary stream simply to check if a readable
+  // version already exists.
+
+  ACE_Auto_Ptr<TAO::Storable_Base> stream
+    (this->factory_->create_stream(context_name_.c_str(), "r"));
+  if (!stream->exists ())
+    {
+      File_Open_Lock_and_Check fg(this, SFG::CREATE_WITHOUT_FILE, false);
+      this->Write (fg.peer ());
+    }
 }
 
 TAO_Storable_Naming_Context::~TAO_Storable_Naming_Context (void)

--- a/TAO/orbsvcs/orbsvcs/Naming/Storable_Naming_Context_ReaderWriter.cpp
+++ b/TAO/orbsvcs/orbsvcs/Naming/Storable_Naming_Context_ReaderWriter.cpp
@@ -14,6 +14,7 @@
 #include "orbsvcs/Naming/Storable.h"
 
 #include "tao/Storable_Base.h"
+#include "tao/Storable_FlatFileStream.h"
 
 TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -27,6 +28,14 @@ void
 TAO_Storable_Naming_Context_ReaderWriter::write (TAO_Storable_Naming_Context & context)
 {
   TAO_NS_Persistence_Header header;
+
+  if (context.storable_context_ == 0)
+    {
+      header.size (0);
+      header.destroyed (0);
+      this->write_header (header);
+      return;
+    }
 
   header.size (static_cast<unsigned int> (context.storable_context_->current_size()));
   header.destroyed (context.destroyed_);
@@ -44,13 +53,13 @@ TAO_Storable_Naming_Context_ReaderWriter::write (TAO_Storable_Naming_Context & c
   ACE_Hash_Map_Entry<TAO_Storable_ExtId,TAO_Storable_IntId> ent = *it;
 
   while (!(it == itend))
-  {
-    TAO_NS_Persistence_Record record;
+    {
+      TAO_NS_Persistence_Record record;
 
-    ACE_CString name;
-    CosNaming::BindingType bt = (*it).int_id_.type_;
-    if (bt ==  CosNaming::ncontext)
-      {
+      ACE_CString name;
+      CosNaming::BindingType bt = (*it).int_id_.type_;
+      if (bt ==  CosNaming::ncontext)
+        {
         CORBA::Object_var
           obj = context.orb_->string_to_object ((*it).int_id_.ref_.in ());
         if (obj->_is_collocated ())

--- a/TAO/orbsvcs/orbsvcs/PortableGroup/PG_Group_List_Store.cpp
+++ b/TAO/orbsvcs/orbsvcs/PortableGroup/PG_Group_List_Store.cpp
@@ -168,7 +168,7 @@ TAO::PG_Group_List_Store::~PG_Group_List_Store ()
 PortableGroup::ObjectGroupId
 TAO::PG_Group_List_Store::get_next_group_id ()
 {
-  File_Guard fg(*this, SFG::ACCESSOR);
+  File_Guard fg(*this, SFG::MUTATOR);
   PortableGroup::ObjectGroupId next_id = this->next_group_id_;
   ++this->next_group_id_;
   this->write (fg.peer ());

--- a/TAO/tao/Storable_File_Guard.cpp
+++ b/TAO/tao/Storable_File_Guard.cpp
@@ -43,7 +43,7 @@ TAO::Storable_File_Guard::init_no_load(Method_Type method_type)
       this->rwflags_ = mode_read;
       break;
     case CREATE_WITHOUT_FILE:
-      mode = "wc";
+      mode = "rwc";
       this->rwflags_ = mode_write | mode_create;
       break;
     case MUTATOR:
@@ -164,8 +164,7 @@ TAO::Storable_File_Guard::release (void)
   if ( ! closed_ )
     {
       if (this->use_backup_ &&
-          (rwflags_ & mode_write) != 0 &&
-          (rwflags_ & mode_create) == 0)
+          (rwflags_ & mode_write) != 0)
         {
           fl_->create_backup ();
         }


### PR DESCRIPTION
These failures are actually quite old (circa 2013) but were masked. OCI TAO addressed the problem by first fixing the errant PG_Group_List_Store file lock, and then simply ignoring the "Error" of not creating a backup for empty persistence files. However this causes the FT_Naming/Failover/Persistence test to fail, so this commit now fixes that behavior, so a backup file is once again created as soon as the primary persistence file is created. 