### PR TITLE
Add support for writing the PID of the started server to a file which…

### DIFF
--- a/TAO/orbsvcs/tests/ImplRepo/airplane_server.cpp
+++ b/TAO/orbsvcs/tests/ImplRepo/airplane_server.cpp
@@ -9,13 +9,10 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
 
   try
     {
-      int retval = server.init (argc, argv);
-
-      if (retval == -1)
+      if (server.init (argc, argv) == -1)
         return -1;
 
-
-      retval = server.run ();
+      int const retval = server.run ();
 
       ACE_DEBUG ((LM_DEBUG, "Paper Airplane Server says goodnight\n"));
 

--- a/TAO/orbsvcs/tests/ImplRepo/airplane_server_i.cpp
+++ b/TAO/orbsvcs/tests/ImplRepo/airplane_server_i.cpp
@@ -9,6 +9,7 @@
 #include "ace/Read_Buffer.h"
 #include "ace/OS_NS_stdio.h"
 #include "ace/OS_NS_sys_time.h"
+#include "ace/OS_NS_unistd.h"
 
 // The server name of the Aiprlane Server
 const char SERVER_NAME[] = "airplane_server";

--- a/TAO/orbsvcs/tests/ImplRepo/airplane_server_i.cpp
+++ b/TAO/orbsvcs/tests/ImplRepo/airplane_server_i.cpp
@@ -22,6 +22,7 @@ Airplane_Server_i::Airplane_Server_i (void)
     poa_manager_ (),
     server_impl_ (0),
     ior_output_file_ (0),
+    pid_output_file_ (0),
     server_name_(SERVER_NAME)
 {
   // Nothing
@@ -30,7 +31,7 @@ Airplane_Server_i::Airplane_Server_i (void)
 int
 Airplane_Server_i::parse_args (void)
 {
-  ACE_Get_Opt get_opts (this->argc_, this->argv_, ACE_TEXT("do:s:"));
+  ACE_Get_Opt get_opts (this->argc_, this->argv_, ACE_TEXT("do:s:p:"));
   int c;
 
   while ((c = get_opts ()) != -1)
@@ -46,6 +47,13 @@ Airplane_Server_i::parse_args (void)
                              "Unable to open %s for writing: %p\n",
                              get_opts.opt_arg ()), -1);
         break;
+      case 'p':  // output the pid to a file.
+        this->pid_output_file_ = ACE_OS::fopen (get_opts.opt_arg (), "w");
+        if (this->pid_output_file_ == 0)
+          ACE_ERROR_RETURN ((LM_ERROR,
+                             "Unable to open %s for writing: %p\n",
+                             get_opts.opt_arg ()), -1);
+        break;
       case 's':  // extension to the server name.
         this->server_name_ = ACE_TEXT_ALWAYS_CHAR (get_opts.opt_arg ());
         break;
@@ -55,6 +63,7 @@ Airplane_Server_i::parse_args (void)
                            "usage:  %s"
                            " [-d]"
                            " [-o <ior_output_file>]"
+                           " [-p <pid_output_file>]"
                            " [-s <the server name>]"
                            "\n",
                            argv_ [0]),
@@ -132,14 +141,14 @@ Airplane_Server_i::init (int argc, ACE_TCHAR** argv)
       CORBA::String_var ior =
         this->orb_->object_to_string (obj.in ());
       if (TAO_debug_level > 0)
-        ACE_DEBUG ((LM_DEBUG, "The ImRified IOR is: <%s>\n", ior.in ()));
+        ACE_DEBUG ((LM_DEBUG, "The ImRified IOR is: <%C>\n", ior.in ()));
 
       TAO_Root_POA* tmp_poa = dynamic_cast<TAO_Root_POA*>(airplane_poa_.in());
       obj = tmp_poa->id_to_reference_i (server_id.in (), false);
       CORBA::String_var plain_ior =
         this->orb_->object_to_string (obj.in ());
       if (TAO_debug_level > 0)
-        ACE_DEBUG ((LM_DEBUG, "The plain IOR is: <%s>\n", plain_ior.in ()));
+        ACE_DEBUG ((LM_DEBUG, "The plain IOR is: <%C>\n", plain_ior.in ()));
 
       // Note : The IORTable will only be used for those clients who try to
       // invoke indirectly using a simple object_key reference
@@ -158,13 +167,19 @@ Airplane_Server_i::init (int argc, ACE_TCHAR** argv)
           ACE_OS::fprintf (this->ior_output_file_, "%s", ior.in ());
           ACE_OS::fclose (this->ior_output_file_);
         }
+
+      if (this->pid_output_file_)
+        {
+          int pid = static_cast<int> (ACE_OS::getpid ());
+          ACE_OS::fprintf (this->pid_output_file_, "%d\n", pid);
+          ACE_OS::fclose (this->pid_output_file_);
+        }
     }
   catch (const CORBA::Exception& ex)
     {
       ex._tao_print_exception ("Airplane_Server_i::init");
       throw;
     }
-
 
   return 0;
 }

--- a/TAO/orbsvcs/tests/ImplRepo/airplane_server_i.h
+++ b/TAO/orbsvcs/tests/ImplRepo/airplane_server_i.h
@@ -11,7 +11,6 @@
  */
 //=============================================================================
 
-
 #if !defined (AIRPLANE_SERVER_I_H)
 #define AIRPLANE_SERVER_I_H
 
@@ -68,7 +67,10 @@ private:
   /// File where the IOR of the server object is stored.
   FILE *ior_output_file_;
 
-  /// the server name
+  /// File where the pid of the server is stored.
+  FILE *pid_output_file_;
+
+  /// The server name
   ACE_CString server_name_;
 };
 


### PR DESCRIPTION
… can be specified using the new -p commandline option

    * TAO/orbsvcs/tests/ImplRepo/airplane_server.cpp:
    * TAO/orbsvcs/tests/ImplRepo/airplane_server_i.cpp:
    * TAO/orbsvcs/tests/ImplRepo/airplane_server_i.h: