### PR TITLE
Added C++11 test for using incomplete types and std::is_base_of

### DIFF
--- a/ACE/tests/Compiler_Features_36_Test.cpp
+++ b/ACE/tests/Compiler_Features_36_Test.cpp
@@ -1,0 +1,47 @@
+/**
+ * This program checks if the compiler doesn't have a certain bug
+ * that we encountered when testing C++11 features
+ */
+
+#include "test_config.h"
+
+#if defined (ACE_HAS_CPP11)
+
+#include <type_traits>
+
+template <typename T>
+struct non_instantiatable
+{
+  typedef typename T::THIS_TYPE_CANNOT_BE_INSTANTIATED type;
+};
+
+int
+run_main (int, ACE_TCHAR *[])
+{
+  ACE_START_TEST (ACE_TEXT("Compiler_Features_36_Test"));
+
+  bool const result = std::is_base_of<non_instantiatable<int>, void>::value;
+  ACE_UNUSED_ARG (result);
+
+  ACE_DEBUG ((LM_INFO,
+              ACE_TEXT ("C++11 support ok\n")));
+
+  ACE_END_TEST;
+
+  return 0;
+}
+
+#else
+int
+run_main (int, ACE_TCHAR *[])
+{
+  ACE_START_TEST (ACE_TEXT("Compiler_Features_36_Test"));
+
+  ACE_DEBUG ((LM_INFO,
+              ACE_TEXT ("No C++11 support enabled\n")));
+
+  ACE_END_TEST;
+  return 0;
+}
+
+#endif

--- a/ACE/tests/run_test.lst
+++ b/ACE/tests/run_test.lst
@@ -109,6 +109,7 @@ Compiler_Features_32_Test
 Compiler_Features_33_Test
 Compiler_Features_34_Test
 Compiler_Features_35_Test
+Compiler_Features_36_Test
 Config_Test: !LynxOS !VxWorks !ACE_FOR_TAO
 Conn_Test: !ACE_FOR_TAO
 DLL_Test: !STATIC Linux

--- a/ACE/tests/tests.mpc
+++ b/ACE/tests/tests.mpc
@@ -826,6 +826,13 @@ project(Compiler_Features_35_Test) : acetest {
   }
 }
 
+project(Compiler_Features_36_Test) : acetest {
+  exename = Compiler_Features_36_Test
+  Source_Files {
+    Compiler_Features_36_Test.cpp
+  }
+}
+
 project(Config Test) : acetest {
   avoids += ace_for_tao
   exename = Config_Test


### PR DESCRIPTION
    * ACE/tests/Compiler_Features_36_Test.cpp:
      Added.

    * ACE/tests/run_test.lst:
    * ACE/tests/tests.mpc: