### PR TITLE
Fixed ssliop corbaloc parser, when there is a comma delimited list

### DIFF
--- a/TAO/orbsvcs/orbsvcs/SSLIOP/SSLIOP_Connector.cpp
+++ b/TAO/orbsvcs/orbsvcs/SSLIOP/SSLIOP_Connector.cpp
@@ -286,7 +286,7 @@ TAO::SSLIOP::Connector::corbaloc_scan (const char *endpoint, size_t &len)
        }
        len = ACE_OS::strlen (endpoint);
    }
-   else if (slash_pos != 0 || comma_pos > slash_pos)
+   else if (comma_pos == 0 || comma_pos > slash_pos)
    {
        // The endpoint address does not extend past the first '/' or ','
        len = slash_pos - endpoint;


### PR DESCRIPTION
... use the same logic as in TAO/tao/Transport_Connector.cpp

Allows using corbaloc:iiop:host:2222,iiop:host:2223/ObjectKey with SSLIOP.