### PR TITLE
Another attempt to silence the Bug 4152 failures on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,19 @@
 *.sdf
 *.sln
 *.suo
+Debug
+*A.cpp
+*A.h
+*A.inl
+*C.cpp
+*C.h
+*C.inl
+*S.cpp
+*S.h
+*S.inl
+*S_T.cpp
+*S_T.h
+*S_T.inl
 
 .depend.*
 GNUmakefile*

--- a/TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.cpp
@@ -260,9 +260,11 @@ AsyncAccessManager::notify_waiters (void)
                     case  ImplementationRepository::AAM_ACTIVE_TERMINATE:
                       throw ImplementationRepository::CannotActivate
                         ("Server terminating.");
-                    default:
-                      throw ImplementationRepository::CannotActivate
-                        ("Unknown Failure");
+                    default: {
+                      ACE_CString reason = ACE_CString ("AAM_Status is ") +
+                        ACE_CString (status_name (this->status_));
+                      throw ImplementationRepository::CannotActivate (reason.c_str());
+                    }
                     }
                 }
               catch (const CORBA::Exception &ex)
@@ -466,11 +468,12 @@ AsyncAccessManager::notify_child_death (int pid)
   if (ImR_Locator_i::debug () > 4)
     {
       ORBSVCS_DEBUG ((LM_DEBUG,
-                      ACE_TEXT ("(%P|%t) AsyncAccessManager(%@), child death, pid = %d, ")
+                      ACE_TEXT ("(%P|%t) AsyncAccessManager(%@), child death, pid = %d, status = %s ")
                       ACE_TEXT ("this info_.pid = %d, prev_pid = %d, waiter count = %d\n"),
-                      this, pid, this->info_->pid, this->prev_pid_, this->rh_list_.size() ));
+                      this, pid, status_name (status_),
+                      this->info_->pid, this->prev_pid_, this->rh_list_.size() ));
     }
-  if (this->info_->pid == pid || this->prev_pid_)
+  if (this->info_->pid == pid || this->prev_pid_ == pid)
     {
       if (this->status_ == ImplementationRepository::AAM_WAIT_FOR_DEATH &&
           this->rh_list_.size() > 0)
@@ -518,7 +521,7 @@ AsyncAccessManager::ping_replied (LiveStatus server)
     case LS_TIMEDOUT:
       this->status (ImplementationRepository::AAM_SERVER_READY);
       break;
-    case LS_CANCELLED:
+    case LS_CANCELED:
       {
         if (this->status_ == ImplementationRepository::AAM_WAIT_FOR_PING)
           {

--- a/TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/AsyncAccessManager.cpp
@@ -262,7 +262,7 @@ AsyncAccessManager::notify_waiters (void)
                         ("Server terminating.");
                     default: {
                       ACE_CString reason = ACE_CString ("AAM_Status is ") +
-                        ACE_CString (status_name (this->status_));
+                        ACE_TEXT_ALWAYS_CHAR (status_name (this->status_));
                       throw ImplementationRepository::CannotActivate (reason.c_str());
                     }
                     }

--- a/TAO/orbsvcs/ImplRepo_Service/ImR_Activator_i.h
+++ b/TAO/orbsvcs/ImplRepo_Service/ImR_Activator_i.h
@@ -52,6 +52,7 @@ struct ACE_Equal_To_pid_t
   typedef ACE_INT32 Act_token_type;
 #endif
 
+  class Active_Pid_Setter;
 
 /**
 * @class ImR_Activator_i
@@ -66,6 +67,8 @@ class Activator_Export ImR_Activator_i : public POA_ImplementationRepository::Ac
                                          public ACE_Event_Handler
 {
  public:
+   friend class Active_Pid_Setter;
+
   ImR_Activator_i (void);
 
   void start_server (const char* name,
@@ -152,7 +155,18 @@ private:
   int max_env_vars_;
 
   bool detach_child_;
-
+  pid_t active_check_pid_;
 };
+
+class Active_Pid_Setter
+  {
+  public:
+    Active_Pid_Setter(ImR_Activator_i &owner, pid_t pid);
+    ~Active_Pid_Setter();
+
+    ImR_Activator_i &owner_;
+
+  };
+
 
 #endif /* IMR_ACTIVATOR_I_H */

--- a/TAO/orbsvcs/ImplRepo_Service/ImR_Locator_i.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/ImR_Locator_i.cpp
@@ -565,8 +565,14 @@ ImR_Locator_i::spawn_pid
   UpdateableServerInfo info(this->repository_, name);
   if (! info.null ())
     {
-      info.edit ()->active_info ()->pid = pid;
-      AsyncAccessManager_ptr aam (this->find_aam (name));
+      if (debug_ > 4)
+        {
+          ORBSVCS_DEBUG ((LM_DEBUG,
+                          ACE_TEXT ("(%P|%t) ImR: Spawn_pid prev pid was %d becoming %d\n"),
+                          info.edit ()->active_info ()->pid, pid));
+        }
+
+      AsyncAccessManager_ptr aam (this->find_aam (name, true));
       if (aam.is_nil ())
         {
           aam = this->find_aam (name, false);
@@ -575,7 +581,7 @@ ImR_Locator_i::spawn_pid
         {
           aam->update_prev_pid ();
         }
-
+      info.edit ()->active_info ()->pid = pid;
       info.edit ()->active_info ()->death_notify = true;
     }
   else
@@ -1156,7 +1162,7 @@ ImR_Locator_i::shutdown_server_i (const Server_Info_Ptr &si,
     }
   catch (const CORBA::TIMEOUT &ex)
     {
-      info.edit ()->reset_runtime ();
+    info.edit ()->reset_runtime ();
       // Note : This is a good thing. It means we didn't waste our time waiting for
       // the server to finish shutting down.
       if (debug_ > 1)
@@ -1172,7 +1178,7 @@ ImR_Locator_i::shutdown_server_i (const Server_Info_Ptr &si,
     }
   catch (const CORBA::COMM_FAILURE& ex)
     {
-      info.edit ()->reset_runtime ();
+    info.edit ()->reset_runtime ();
       if (debug_ > 1)
         {
           ORBSVCS_DEBUG ((LM_DEBUG,
@@ -1189,7 +1195,7 @@ ImR_Locator_i::shutdown_server_i (const Server_Info_Ptr &si,
       CORBA::ULong minor = ex.minor () & TAO_MINOR_MASK;
       if (minor != TAO_POA_DISCARDING && minor != TAO_POA_HOLDING)
         {
-          info.edit ()->reset_runtime ();
+        info.edit ()->reset_runtime ();
         }
       if (debug_ > 1)
         {
@@ -1484,7 +1490,7 @@ ImR_Locator_i::connect_activator (Activator_Info& info)
 
       if (CORBA::is_nil (obj.in ()))
         {
-          info.reset_runtime ();
+        info.reset_runtime ();
           return;
         }
 
@@ -1498,7 +1504,7 @@ ImR_Locator_i::connect_activator (Activator_Info& info)
 
       if (CORBA::is_nil (info.activator.in ()))
         {
-          info.reset_runtime ();
+        info.reset_runtime ();
           return;
         }
 
@@ -1507,9 +1513,9 @@ ImR_Locator_i::connect_activator (Activator_Info& info)
                         ACE_TEXT ("(%P|%t) ImR: Connected to activator <%C>\n"),
                         info.name.c_str ()));
     }
-  catch (const CORBA::Exception&)
+  catch (const CORBA::Exception& ex)
     {
-      info.reset_runtime ();
+    info.reset_runtime ();
     }
 }
 
@@ -1570,7 +1576,7 @@ ImR_Locator_i::connect_server (UpdateableServerInfo& info)
 
   if (sip->ior.length () == 0)
     {
-      sip->reset_runtime ();
+    sip->reset_runtime ();
       return; // can't connect
     }
 
@@ -1580,7 +1586,7 @@ ImR_Locator_i::connect_server (UpdateableServerInfo& info)
 
       if (CORBA::is_nil (obj.in ()))
         {
-          sip->reset_runtime ();
+        sip->reset_runtime ();
           return;
         }
 
@@ -1605,7 +1611,7 @@ ImR_Locator_i::connect_server (UpdateableServerInfo& info)
 
 
     }
-  catch (const CORBA::Exception&)
+  catch (const CORBA::Exception& ex)
     {
       sip->reset_runtime ();
     }

--- a/TAO/orbsvcs/ImplRepo_Service/ImplRepo_Service.mpc
+++ b/TAO/orbsvcs/ImplRepo_Service/ImplRepo_Service.mpc
@@ -54,7 +54,7 @@ project(ImR_Activator_IDL) : orbsvcslib, orbsvcs_output, conv_lib, valuetype, dy
   }
 }
 
-project(ImR_Locator_IDL) : orbsvcslib, orbsvcs_output, conv_lib, valuetype, portableserver, messaging, avoids_minimum_corba, avoids_corba_e_compact, avoids_corba_e_micro,tao_versioning_idl_defaults {
+project(ImR_Locator_IDL) : orbsvcslib, orbsvcs_output, conv_lib, valuetype, portableserver, messaging, dynamicinterface, avoids_minimum_corba, avoids_corba_e_compact, avoids_corba_e_micro,tao_versioning_idl_defaults {
   sharedname   = TAO_ImR_Locator_IDL
   after       += ImR_Activator_IDL
   libs        += TAO_ImR_Activator_IDL TAO_Async_ImR_Client_IDL
@@ -78,7 +78,7 @@ project(ImR_Locator_IDL) : orbsvcslib, orbsvcs_output, conv_lib, valuetype, port
   }
 }
 
-project(ImR_Activator) : orbsvcslib, orbsvcs_output, conv_lib, acexml, avoids_minimum_corba, avoids_corba_e_compact, avoids_corba_e_micro, valuetype, portableserver, messaging, pi, codecfactory, svc_utils {
+project(ImR_Activator) : orbsvcslib, orbsvcs_output, conv_lib, acexml, avoids_minimum_corba, avoids_corba_e_compact, avoids_corba_e_micro, valuetype, portableserver, messaging, dynamicinterface, pi, codecfactory, svc_utils {
   sharedname   = TAO_ImR_Activator
   dynamicflags += ACTIVATOR_BUILD_DLL
   after       += ImR_Locator_IDL

--- a/TAO/orbsvcs/ImplRepo_Service/LiveCheck.h
+++ b/TAO/orbsvcs/ImplRepo_Service/LiveCheck.h
@@ -33,15 +33,18 @@ class PingReceiver;
  *
  * @brief indication of the known condition of a target server
  *
- *  LS_UNKNOWN   - The server hasn't yet been pinged
+ *  LS_INIT      - This is a new entry
+ *  LS_UNKNOWN   - The server status was reset
  *  LS_PING_AWAY - A ping request has been issued, waiting for reply
  *  LS_DEAD      - The ping failed for reasons other than POA Activation
  *  LS_ALIVE     - The server positively acknowledged a ping
  *  LS_TRANSIENT - The server connected, but actively raised a transient
  *  LS_LAST_TRANSIENT - The maximum number of retries is reached
  *  LS_TIMEDOUT  - The server connected, but never returned any result.
+ *  LS_CANCELED  - The ping was canceled by the owner
  */
 enum LiveStatus {
+  LS_INIT,
   LS_UNKNOWN,
   LS_PING_AWAY,
   LS_DEAD,
@@ -49,7 +52,7 @@ enum LiveStatus {
   LS_TRANSIENT,
   LS_LAST_TRANSIENT,
   LS_TIMEDOUT,
-  LS_CANCELLED
+  LS_CANCELED
 };
 
 //---------------------------------------------------------------------------
@@ -278,7 +281,7 @@ class Locator_Export LiveCheck : public ACE_Event_Handler
                                   LiveEntry *,
                                   ACE_Hash<ACE_CString>,
                                   ACE_Equal_To<ACE_CString>,
-                                  TAO_SYNCH_MUTEX> LiveEntryMap;
+                                  ACE_Null_Mutex> LiveEntryMap;
   typedef ACE_Unbounded_Set<LiveEntry *> PerClientStack;
   typedef ACE_Unbounded_Set<ACE_CString> NameStack;
 

--- a/TAO/orbsvcs/ImplRepo_Service/Server_Info.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/Server_Info.cpp
@@ -297,7 +297,6 @@ Server_Info::reset_runtime (void)
   this->partial_ior = "";
   Server_Info *startup = this->active_info ();
   startup->ior = "";
-  //  startup->pid = 0;
   startup->death_notify = false;
   startup->last_ping = ACE_Time_Value::zero;
   startup->server = ImplementationRepository::ServerObject::_nil ();

--- a/TAO/orbsvcs/ImplRepo_Service/tao_imr_i.cpp
+++ b/TAO/orbsvcs/ImplRepo_Service/tao_imr_i.cpp
@@ -29,6 +29,8 @@ TAO_IMR_i::~TAO_IMR_i (void)
 int
 TAO_IMR_i::run ()
 {
+ACE_Time_Value tv(0, 100000);
+ACE_OS::sleep(tv);
   if (this->op_.get () == 0)
     {
       ORBSVCS_ERROR ((LM_ERROR, "Unknown operation"));

--- a/TAO/orbsvcs/tests/ImplRepo/Bug_4152_Regression/Test_i.cpp
+++ b/TAO/orbsvcs/tests/ImplRepo/Bug_4152_Regression/Test_i.cpp
@@ -1,6 +1,8 @@
 /* -*- C++ -*-  */
 
 #include "Test_i.h"
+#include "ace/OS_NS_unistd.h"
+#include "ace/OS_NS_stdio.h"
 
 CORBA::Short
 Test_i::get_server_num (void)
@@ -13,5 +15,3 @@ Test_i::terminate (void)
 {
   exit (0);
 }
-
-

--- a/TAO/orbsvcs/tests/ImplRepo/Bug_4152_Regression/run_test.pl
+++ b/TAO/orbsvcs/tests/ImplRepo/Bug_4152_Regression/run_test.pl
@@ -51,13 +51,14 @@ $actlogfile = "act.log";
 $cltlogfile = "client.log";
 $imrlogfile = "imr.log";
 $srvlogfile = "server.log";
+$tilogfile = "ti.log";
 
 $imr_imriorfile = $imr->LocalFile ($imriorfile);
 $act_imriorfile = $act->LocalFile ($imriorfile);
 $ti_imriorfile = $ti->LocalFile ($imriorfile);
 $srv_imriorfile = $srv->LocalFile ($imriorfile);
 $act_actiorfile = $act->LocalFile ($actiorfile);
-
+$srv_statusfile = $srv->LocalFile ($statusfile);
 
 $IMR = $imr->CreateProcess ("$ENV{TAO_ROOT}/orbsvcs/ImplRepo_Service/tao_imr_locator");
 $ACT = $act->CreateProcess ("$ENV{TAO_ROOT}/orbsvcs/ImplRepo_Service/tao_imr_activator");
@@ -68,6 +69,9 @@ $CLINW = $clinw->CreateProcess ("client");
 $SRV = $srv->CreateProcess ("server");
 $server_cmd = $SRV->Executable();
 $srv_server_cmd = $imr->LocalFile ($server_cmd);
+
+$ti_cmd_base = "-ORBInitRef ImplRepoService=file://$ti_imriorfile ";
+$ti_cmd_base .= "-ORBVerboseLogging 1 -ORBDebugLevel $debug_level -ORBLogfile $tilogfile " if ($debug_level > 0);
 
 $stdout_file      = "test.out";
 $stderr_file      = "test.err";
@@ -87,13 +91,14 @@ sub deletefiles
     $ti->DeleteFile ($stdout_file);
     $ti->DeleteFile ($stderr_file);
 
-    $srv->DeleteFile ($statusfile);
+    $res = $srv->DeleteFile ($statusfile);
 
     if ($logs_too == 1) {
         $imr->DeleteFile ($imrlogfile);
         $act->DeleteFile ($actlogfile);
         $cli->DeleteFile ($cltlogfile);
         $srv->DeleteFile ($srvlogfile);
+        $ti->DeleteFile ($tilogfile);
     }
 }
 
@@ -119,11 +124,17 @@ sub restore_output
 
 sub register_server
 {
+    if ($debug_level > 0) {
+        open (my $log, '>>', $tilogfile) or die "failed to append to $tilogfile\n";
+        say $log "\nregister server\n";
+        close $log;
+    }
+
     my $expected = shift;
     my $debugarg = "-ORBVerboseLogging 1 -ORBDebugLevel $debug_level -ORBLogfile $srvlogfile" if ($debug_level > 0);
     my $endpointarg = "-ORBDottedDecimalAddresses 1 -ORBListenEndpoints iiop://127.0.0.1:" if ($no_dns == 1);
 
-    $TI->Arguments ("-ORBInitRef ImplRepoService=file://$ti_imriorfile ".
+    $TI->Arguments ($ti_cmd_base.
                     "add TestObject_a -c \"".
                     $srv_server_cmd .
                     " -ORBUseIMR 1 -p $poa_delay -ORBLingerTimeout 0 " .
@@ -193,11 +204,16 @@ sub start_client_no_wait
 
 sub shutdown_server
 {
+    if ($debug_level > 0) {
+        open (my $log, '>>', $tilogfile) or die "failed to append to $tilogfile\n";
+        say $log "\nshutdown server\n";
+        close $log;
+    }
     # Shutting down any server object within the server will shutdown the whole server
-    $TI->Arguments ("-ORBInitRef ImplRepoService=file://$ti_imriorfile ".
+    $TI->Arguments ($ti_cmd_base .
                     "shutdown TestObject_a" );
     $TI_status = $TI->SpawnWaitKill ($ti->ProcessStartWaitInterval());
-    if ($TI_status != 0  && $TI_status != 5) {
+    if ($TI_status != 0  && $TI_status != 6) {
         print STDERR "ERROR: tao_imr shutdown returned $TI_status\n";
         $status = 1;
     }
@@ -205,8 +221,13 @@ sub shutdown_server
 
 sub manual_start_server
 {
+    if ($debug_level > 0) {
+        open (my $log, '>>', $tilogfile) or die "failed to append to $tilogfile\n";
+        say $log "\nmanual start server\n";
+        close $log;
+    }
     # Shutting down any server object within the server will shutdown the whole server
-    $TI->Arguments ("-ORBInitRef ImplRepoService=file://$ti_imriorfile ".
+    $TI->Arguments ($ti_cmd_base .
                     "start TestObject_a" );
     $TI_status = $TI->SpawnWaitKill ($ti->ProcessStartWaitInterval());
     if ($TI_status != 0) {
@@ -228,6 +249,7 @@ sub validate_servers
             kill $pids[$i];
         }
     }
+    close FILE;
 }
 
 
@@ -286,34 +308,35 @@ sub double_server_test
     print "Manual start\n";
     manual_start_server();
 
-    if ($status != 0) {
-        return 1;
-    }
+    if ($status == 0) {
 
-    print "Initial client request to kill server\n";
-    run_client ("-k");
+        print "Initial client request to kill server\n";
+        run_client ("-k");
+        sleep (1);
 
-   sleep (1);
+        print "Second client request to reactivate server \n";
+        start_client_no_wait ();
 
-    print "Second client request to reactivate server \n";
-    start_client_no_wait ();
+        print "Second shutdown of server\n";
+        shutdown_server ();
 
-    print "Second shutdown of server\n";
-    shutdown_server ();
+        print "manual start\n";
+        manual_start_server();
 
-    print "manual start\n";
-    manual_start_server();
+        print "Third client request should just work \n";
+        run_client ("");
 
-    print "Third client request should just work \n";
-    run_client ("");
+        print "delay before shutdown\n";
+        sleep (5);
 
-    print "final shutdown\n";
-    shutdown_server ();
+        print "final shutdown\n";
+        shutdown_server ();
 
-    my $CLINW_status = $CLINW->TerminateWaitKill ($clinw->ProcessStopWaitInterval());
-    if ($CLINW_status != 0) {
-	print STDERR "ERROR: no-wait client returned $CLINW_status\n";
-	$status = 1;
+        my $CLINW_status = $CLINW->TerminateWaitKill ($clinw->ProcessStopWaitInterval());
+        if ($CLINW_status != 0) {
+            print STDERR "ERROR: no-wait client returned $CLINW_status\n";
+            $status = 1;
+        }
     }
 
     my $ACT_status = $ACT->TerminateWaitKill ($act->ProcessStopWaitInterval());

--- a/TAO/utils/logWalker/Invocation.cpp
+++ b/TAO/utils/logWalker/Invocation.cpp
@@ -238,10 +238,11 @@ Invocation::dump_rel_time (ostream &strm, const ACE_Time_Value &tv, const ACE_Ti
   int hours = (int)(reltime.sec()) / 3600;
   int min = (int)(reltime.sec() %3600) / 60;
   int sec = (int)(reltime.sec()) % 60;
+  int subsec = (int)(reltime.usec()/1000);
 
   char buffer[20];
   ACE_OS::snprintf (buffer, 20, "%d:%02d:%02d.%03d",
-              hours, min, sec, reltime.usec()/1000);
+              hours, min, sec, subsec);
 
   strm << buffer << ' ';
 }

--- a/TAO/utils/logWalker/Log.cpp
+++ b/TAO/utils/logWalker/Log.cpp
@@ -265,13 +265,13 @@ Log::parse_dump_giop_msg_i (void)
       inv->init (this->line_, this->offset_, this->thr_);
       this->thr_->push_invocation (inv);
       target = inv->octets(true);
-      target->time (this->time_);
       if (target == 0)
         {
           ACE_ERROR ((LM_ERROR, "%d: no target octets for new recv reqeust, id = %d\n",
                       this->offset_, rid));
           return;
         }
+      target->time (this->time_);
       break;
     }
     case 0: // sending request
@@ -289,13 +289,19 @@ Log::parse_dump_giop_msg_i (void)
         }
       inv->init (this->line_, this->offset_, this->thr_);
       target = inv->octets(mode == 0);
-      target->time (this->time_);
-      if (target == 0 && mode == 3)
+      if (target == 0)
         {
-          ACE_ERROR ((LM_ERROR,
-                      "%d: could not map invocation to target for req_id %d\n",
-                      this->offset_, rid));
-          return;
+          if (mode == 3)
+            {
+              ACE_ERROR ((LM_ERROR,
+                          "%d: could not map invocation to target for req_id %d\n",
+                          this->offset_, rid));
+              return;
+            }
+        }
+      else
+        {
+          target->time (this->time_);
         }
 //       if (mode == 3)
 //         this->thr_->exit_wait(pp, this->offset_);


### PR DESCRIPTION
This time the behavior of the Activator is modified to accommodate the peculiar behavior of the client trying to open a new connection to a recently closed acceptor. This is all fine because it is modifying test-specific behavior that is only relevant on non-windows systems anyway.